### PR TITLE
phase2/3: response scrubbing — DTO allowlist layer, central error handler, log redaction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What
+
+<!-- Summary of the change -->
+
+## Data Minimization & Leak Prevention gate
+
+Required for every PR touching an API response, logging, or error handling
+(see `docs/plan/criticseven-modernization-plan.md`, Standing Requirement):
+
+- [ ] Every API response goes through an explicit-allowlist DTO in `server/serializers/` — no raw model documents or upstream payloads sent to the client, no select-minus/denylist shaping
+- [ ] No email, password/auth-code hashes, raw `HonestyLog` entries, or internal `_id` (where a public id suffices) in any response
+- [ ] Error responses: generic message + error code only in production; full detail stays in server logs (central `errorHandler`, no per-route `res.status(500).send(error.message)`)
+- [ ] No `console.log`/`console.error` of request bodies, user objects, auth codes, or raw upstream errors (axios errors embed the TMDB `api_key`)
+- [ ] Request logging (morgan) does not log bodies; `/auth/*` URLs are logged without query strings
+
+Auth routes only (Phase 3+):
+
+- [ ] `POST /auth/verify-code` response never echoes the submitted or stored code
+- [ ] `POST /auth/request-code` returns the identical response whether or not the email exists (no account enumeration)

--- a/server/actions/movies.ts
+++ b/server/actions/movies.ts
@@ -1,74 +1,77 @@
-import {Request, Response} from 'express'
+import {NextFunction, Request, Response} from 'express'
+import {
+	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO
+} from '../serializers'
 import {TmdbMovie} from '../tmdbWrapper'
 
 const Tmdb = new TmdbMovie(process.env.API_KEY)
 
-export const getPopular = async(request: Request, response: Response) => {
+export const getPopular = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const popularMovies = await Tmdb.getPopularMovies()
 
-		response.send(popularMovies)
+		response.send(toMovieListDTO(popularMovies))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getLatest = async(request: Request, response: Response) => {
+export const getLatest = async(request: Request, response: Response, next: NextFunction) => {
 	try {
-		const latestMovies = await Tmdb.getLatestMovies()
+		const latestMovie = await Tmdb.getLatestMovies()
 
-		response.send(latestMovies)
+		response.send(toMovieDetailsDTO(latestMovie))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getUpcoming = async(request: Request, response: Response) => {
+export const getUpcoming = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const upcomingMovies = await Tmdb.getUpcomingMovies()
 
-		response.send(upcomingMovies)
+		response.send(toMovieListDTO(upcomingMovies))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getDetails = async(request: Request, response: Response) => {
+export const getDetails = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const movieDetails = await Tmdb.getMovieDetails(String(request.query.movieId))
 
-		response.send(movieDetails)
+		response.send(toMovieDetailsDTO(movieDetails))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getCredits = async(request: Request, response: Response) => {
+export const getCredits = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const movieCredits = await Tmdb.getMovieCredits(String(request.query.movieId))
 
-		response.send(movieCredits)
+		response.send(toMovieCreditsDTO(movieCredits))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getNowPlaying = async(request: Request, response: Response) => {
+export const getNowPlaying = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const nowPlaying = await Tmdb.getPlayingMovies()
 
-		response.send(nowPlaying)
+		response.send(toMovieListDTO(nowPlaying))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }
 
-export const getImages = async(request: Request, response: Response) => {
+export const getImages = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const movieImages = await Tmdb.getMovieImages(String(request.query.movieId))
 
-		response.send(movieImages)
+		response.send(toMovieImagesDTO(movieImages))
 	} catch (error) {
-		console.error(error)
+		next(error)
 	}
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import http from 'http'
 import logger from 'morgan'
 import path from 'path'
 import {connectToDatabase} from './database/connect'
+import {errorHandler} from './middleware/errorHandler'
 import routes from './routes'
 
 connectToDatabase().catch(error => {
@@ -20,6 +21,13 @@ const port = process.env.PORT || 5000
 
 app.use(express.static(path.join(__dirname, 'public')))
 
+// Morgan logs method/url/status only — never request bodies. Auth URLs are
+// additionally stripped of query strings so emails/codes can't reach the log.
+logger.token('url', (request: express.Request) => {
+	const url = request.originalUrl || request.url || ''
+
+	return url.startsWith('/auth') ? url.split('?')[0] : url
+})
 app.use(logger('dev'))
 app.use(express.json())
 app.use(
@@ -29,6 +37,7 @@ app.use(
 )
 app.use(cookieParser())
 app.use('/', routes)
+app.use(errorHandler)
 
 const debug = debugLib('criticseven:server')
 

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,0 +1,28 @@
+import {NextFunction, Request, Response} from 'express'
+
+/*
+ * Secrets travel in upstream request URLs (TMDB api_key is a query param),
+ * so anything derived from an error — message, stack, config — is scrubbed
+ * before it reaches the server log.
+ */
+function redactSecrets(text: string): string {
+	return text.replace(/api_key=[^&\s'"]+/g, 'api_key=REDACTED')
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function errorHandler(error: Error, request: Request, response: Response, next: NextFunction) {
+	const isProduction = process.env.NODE_ENV === 'production'
+
+	console.error(
+		`[error] ${request.method} ${request.path}:`,
+		redactSecrets(error.message),
+		isProduction ? '' : `\n${redactSecrets(error.stack ?? '')}`
+	)
+
+	response.status(500).json({
+		error: {
+			code: 'INTERNAL_ERROR',
+			message: isProduction ? 'Internal server error' : redactSecrets(error.message)
+		}
+	})
+}

--- a/server/serializers/README.md
+++ b/server/serializers/README.md
@@ -1,0 +1,18 @@
+# Serializers (response DTOs)
+
+Every API response is shaped here before it leaves the server — explicit field
+allowlist per response type, never "full document minus a few deleted fields".
+See "Standing Requirement — Data Minimization & Leak Prevention" in
+`docs/plan/criticseven-modernization-plan.md`.
+
+Rules for adding a DTO when a new model gets an API response (User,
+TrailerOpinion, Review, Vote, etc. in Phase 2+):
+
+- One exported `to<Name>DTO()` function per response shape; name every field.
+- Never include: email on public payloads (username is the public identity),
+  password/auth-code hashes, raw `HonestyLog` entries, internal `_id` where a
+  public id suffices, or `Config` values beyond the public thresholds.
+- Route handlers call the DTO before `response.send()` — raw model documents
+  and raw upstream API payloads must not be sent directly.
+
+Planned example: `UserPublicDTO { username, honestyScore, isLowTrust }`.

--- a/server/serializers/index.ts
+++ b/server/serializers/index.ts
@@ -1,0 +1,1 @@
+export * from './movies'

--- a/server/serializers/movies.ts
+++ b/server/serializers/movies.ts
@@ -1,0 +1,150 @@
+/*
+ * Response DTOs — explicit field allowlist per response type (see
+ * "Standing Requirement — Data Minimization" in docs/plan).
+ * Every field sent to the client is named here; anything TMDB adds
+ * upstream is dropped unless deliberately allowlisted.
+ */
+
+type TmdbPayload = Record<string, unknown>
+
+export interface MovieSummaryDTO {
+	id: number
+	title: string
+	overview: string
+	poster_path: string | null
+	backdrop_path: string | null
+	release_date: string
+	vote_average: number
+	vote_count: number
+	genre_ids: number[]
+}
+
+export interface MovieDetailsDTO extends Omit<MovieSummaryDTO, 'genre_ids'> {
+	runtime: number | null
+	tagline: string
+	genres: Array<{id: number, name: string}>
+}
+
+export interface MovieListDTO {
+	page: number
+	total_pages: number
+	total_results: number
+	results: MovieSummaryDTO[]
+}
+
+export interface CastMemberDTO {
+	id: number
+	name: string
+	character: string
+	profile_path: string | null
+	order: number
+}
+
+export interface CrewMemberDTO {
+	id: number
+	name: string
+	job: string
+	department: string
+	profile_path: string | null
+}
+
+export interface MovieCreditsDTO {
+	id: number
+	cast: CastMemberDTO[]
+	crew: CrewMemberDTO[]
+}
+
+export interface MovieImageDTO {
+	file_path: string
+	width: number
+	height: number
+	aspect_ratio: number
+}
+
+export interface MovieImagesDTO {
+	id: number
+	backdrops: MovieImageDTO[]
+	posters: MovieImageDTO[]
+}
+
+export function toMovieSummaryDTO(movie: TmdbPayload): MovieSummaryDTO {
+	return {
+		id: movie.id as number,
+		title: movie.title as string,
+		overview: movie.overview as string,
+		poster_path: (movie.poster_path as string) ?? null,
+		backdrop_path: (movie.backdrop_path as string) ?? null,
+		release_date: movie.release_date as string,
+		vote_average: movie.vote_average as number,
+		vote_count: movie.vote_count as number,
+		genre_ids: (movie.genre_ids as number[]) ?? []
+	}
+}
+
+export function toMovieDetailsDTO(movie: TmdbPayload): MovieDetailsDTO {
+	return {
+		id: movie.id as number,
+		title: movie.title as string,
+		overview: movie.overview as string,
+		poster_path: (movie.poster_path as string) ?? null,
+		backdrop_path: (movie.backdrop_path as string) ?? null,
+		release_date: movie.release_date as string,
+		vote_average: movie.vote_average as number,
+		vote_count: movie.vote_count as number,
+		runtime: (movie.runtime as number) ?? null,
+		tagline: (movie.tagline as string) ?? '',
+		genres: (movie.genres as Array<{id: number, name: string}>) ?? []
+	}
+}
+
+export function toMovieListDTO(payload: TmdbPayload): MovieListDTO {
+	const results = (payload.results as TmdbPayload[]) ?? []
+
+	return {
+		page: payload.page as number,
+		total_pages: payload.total_pages as number,
+		total_results: payload.total_results as number,
+		results: results.map(toMovieSummaryDTO)
+	}
+}
+
+export function toMovieCreditsDTO(payload: TmdbPayload): MovieCreditsDTO {
+	const cast = (payload.cast as TmdbPayload[]) ?? []
+
+	const crew = (payload.crew as TmdbPayload[]) ?? []
+
+	return {
+		id: payload.id as number,
+		cast: cast.map(member => ({
+			id: member.id as number,
+			name: member.name as string,
+			character: member.character as string,
+			profile_path: (member.profile_path as string) ?? null,
+			order: member.order as number
+		})),
+		crew: crew.map(member => ({
+			id: member.id as number,
+			name: member.name as string,
+			job: member.job as string,
+			department: member.department as string,
+			profile_path: (member.profile_path as string) ?? null
+		}))
+	}
+}
+
+function toMovieImageDTO(image: TmdbPayload): MovieImageDTO {
+	return {
+		file_path: image.file_path as string,
+		width: image.width as number,
+		height: image.height as number,
+		aspect_ratio: image.aspect_ratio as number
+	}
+}
+
+export function toMovieImagesDTO(payload: TmdbPayload): MovieImagesDTO {
+	return {
+		id: payload.id as number,
+		backdrops: ((payload.backdrops as TmdbPayload[]) ?? []).map(toMovieImageDTO),
+		posters: ((payload.posters as TmdbPayload[]) ?? []).map(toMovieImageDTO)
+	}
+}

--- a/server/serializers/tests/movies.test.js
+++ b/server/serializers/tests/movies.test.js
@@ -1,0 +1,79 @@
+import {
+	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO, toMovieSummaryDTO
+} from '../movies'
+
+const tmdbMovie = {
+	id: 550,
+	title: 'Fight Club',
+	overview: 'An insomniac office worker...',
+	poster_path: '/poster.jpg',
+	backdrop_path: '/backdrop.jpg',
+	release_date: '1999-10-15',
+	vote_average: 8.4,
+	vote_count: 26000,
+	genre_ids: [18],
+	adult: false,
+	popularity: 61.4,
+	video: false,
+	original_language: 'en'
+}
+
+describe('movie serializers allowlist', () => {
+	test('summary DTO drops non-allowlisted TMDB fields', () => {
+		const dto = toMovieSummaryDTO(tmdbMovie)
+
+		expect(Object.keys(dto).sort()).toEqual([
+			'backdrop_path', 'genre_ids', 'id', 'overview', 'poster_path',
+			'release_date', 'title', 'vote_average', 'vote_count'
+		])
+		expect(dto.title).toBe('Fight Club')
+	})
+
+	test('details DTO drops non-allowlisted TMDB fields', () => {
+		const dto = toMovieDetailsDTO({
+			...tmdbMovie, runtime: 139, tagline: 'Mischief.', genres: [{id: 18, name: 'Drama'}], budget: 63000000, imdb_id: 'tt0137523'
+		})
+
+		expect(Object.keys(dto).sort()).toEqual([
+			'backdrop_path', 'genres', 'id', 'overview', 'poster_path',
+			'release_date', 'runtime', 'tagline', 'title', 'vote_average', 'vote_count'
+		])
+	})
+
+	test('list DTO shapes pagination and maps results', () => {
+		const dto = toMovieListDTO({
+			page: 1, total_pages: 10, total_results: 200, results: [tmdbMovie], dates: {maximum: 'x', minimum: 'y'}
+		})
+
+		expect(Object.keys(dto).sort()).toEqual(['page', 'results', 'total_pages', 'total_results'])
+		expect(dto.results).toHaveLength(1)
+		expect(dto.results[0].adult).toBeUndefined()
+	})
+
+	test('credits DTO allowlists cast and crew members', () => {
+		const dto = toMovieCreditsDTO({
+			id: 550,
+			cast: [{
+				id: 819, name: 'Edward Norton', character: 'The Narrator', profile_path: '/p.jpg', order: 0, cast_id: 4, credit_id: 'abc'
+			}],
+			crew: [{
+				id: 7467, name: 'David Fincher', job: 'Director', department: 'Directing', profile_path: '/d.jpg', credit_id: 'def'
+			}]
+		})
+
+		expect(Object.keys(dto.cast[0]).sort()).toEqual(['character', 'id', 'name', 'order', 'profile_path'])
+		expect(Object.keys(dto.crew[0]).sort()).toEqual(['department', 'id', 'job', 'name', 'profile_path'])
+	})
+
+	test('images DTO allowlists image entries and tolerates missing arrays', () => {
+		const dto = toMovieImagesDTO({
+			id: 550,
+			backdrops: [{
+				file_path: '/b.jpg', width: 1280, height: 720, aspect_ratio: 1.78, iso_639_1: 'en', vote_average: 5
+			}]
+		})
+
+		expect(Object.keys(dto.backdrops[0]).sort()).toEqual(['aspect_ratio', 'file_path', 'height', 'width'])
+		expect(dto.posters).toEqual([])
+	})
+})

--- a/server/tmdbWrapper/movieDBWrapper.ts
+++ b/server/tmdbWrapper/movieDBWrapper.ts
@@ -2,6 +2,9 @@ import axios from 'axios'
 
 const apiBaseURL = 'https://api.themoviedb.org/3'
 
+// Errors propagate to the route handlers, which forward them to the central
+// error middleware — no catch-and-swallow here (it used to hang requests and
+// dump axios errors, api_key included, to the console).
 export default class TmdbMovie {
   apiKey: string | undefined
 
@@ -13,86 +16,58 @@ export default class TmdbMovie {
   }
 
   async getPopularMovies() {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/discover/movie?api_key=${this.apiKey}&sort_by=popularity.desc`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/discover/movie?api_key=${this.apiKey}&sort_by=popularity.desc`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getLatestMovies() {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/latest?api_key=${this.apiKey}&language=${this.language}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/latest?api_key=${this.apiKey}&language=${this.language}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getUpcomingMovies(pageNumber = '1') {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/upcoming?api_key=${this.apiKey}&language=${this.language}&page=${pageNumber}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/upcoming?api_key=${this.apiKey}&language=${this.language}&page=${pageNumber}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getPlayingMovies(pageNumber = '1') {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/now_playing?api_key=${this.apiKey}&language=${this.language}&page=${pageNumber}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/now_playing?api_key=${this.apiKey}&language=${this.language}&page=${pageNumber}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getMovieDetails(movieId: string) {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/${movieId}?api_key=${this.apiKey}&language=${this.language}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/${movieId}?api_key=${this.apiKey}&language=${this.language}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getMovieImages(movieId: string) {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/${movieId}/images?api_key=${this.apiKey}&language=${this.language}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/${movieId}/images?api_key=${this.apiKey}&language=${this.language}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 
   async getMovieCredits(movieId: string) {
-    try {
-      const { data } = await axios.get(
-        `${apiBaseURL}/movie/${movieId}/credits?api_key=${this.apiKey}&language=${this.language}`
-      )
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/${movieId}/credits?api_key=${this.apiKey}&language=${this.language}`
+    )
 
-      return data
-    } catch (error) {
-      console.error(error)
-    }
+    return data
   }
 }


### PR DESCRIPTION
## What

Implements the "Standing Requirement — Data Minimization & Leak Prevention" gate from the modernization plan for everything currently live, and sets up the enforcement pattern for future phases.

- **`server/serializers/`** — explicit field-allowlist DTOs for every live API response (movie list, details, credits, images). Raw TMDB payloads no longer reach the client. README documents the pattern + never-send rules for Phase 2+ models (User, TrailerOpinion, Review, Vote).
- **Central `errorHandler` middleware** — production clients get `{error: {code: 'INTERNAL_ERROR', message: 'Internal server error'}}`; full detail stays in server logs with `api_key=…` redacted from messages/stacks.
- **tmdbWrapper** — removed catch-and-swallow blocks. They hung requests / returned empty 200s on failure, and `console.error(error)` dumped full axios errors — including `config.url` with the TMDB `api_key` — into logs (14 sites total). Errors now propagate to the error middleware. This also supersedes the Phase 1.5 `res.status(500)` hotfix, which never landed.
- **Morgan** — confirmed no request-body logging anywhere; `url` token override strips query strings on `/auth/*` so emails/codes can't reach request logs once auth exists.
- **PR template** — data-minimization gate checklist (none existed), including Phase 3 auth items: verify-code must not echo the code, request-code must not confirm/deny account existence.

## Not in scope

- `GET /movies` handler still missing (Phase 1.5 item 2, never landed) — separate branch.
- Auth routes don't exist yet; their checks are captured in the PR template for Phase 3.

## Data Minimization & Leak Prevention gate

- [x] Every API response goes through an explicit-allowlist DTO in `server/serializers/`
- [x] No email, hashes, `HonestyLog`, or internal `_id` in any response (no models live yet; pattern documented)
- [x] Error responses: generic message + code in production; detail server-log only
- [x] No console logging of request bodies, user objects, auth codes, or raw upstream errors
- [x] Morgan logs no bodies; `/auth/*` URLs logged without query strings

## Test plan

- `pnpm test` — 12/12 (new serializer allowlist tests assert non-allowlisted TMDB fields are dropped)
- `pnpm lint`, `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Movie API responses now include only approved, relevant information, reducing exposure of sensitive or internal data.
  * Request and error logging is safer, with credentials and sensitive request details redacted.
* **Bug Fixes**
  * API failures now use consistent error handling and return a standardized internal-error response.
  * Production error messages no longer expose implementation details.
* **Documentation**
  * Added guidance for minimizing data exposure in API responses, logs, and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->