### PR TITLE
phase3/auth: Turnstile-gated request-code, User phone-verification fi…

### DIFF
--- a/server/actions/auth.ts
+++ b/server/actions/auth.ts
@@ -1,0 +1,71 @@
+import crypto from 'crypto'
+import { NextFunction, Request, Response } from 'express'
+import { AuthCode } from '../database/models/AuthCode'
+import { User } from '../database/models/User'
+import { hashValue } from '../lib/hash'
+import { isRateLimited, recordAttempt } from '../lib/rateLimit'
+import { verifyTurnstileToken } from '../lib/turnstile'
+
+const CODE_TTL_MINUTES = 10
+
+/*
+ * Always resolves to the same generic body regardless of why a code wasn't
+ * actually sent (bad Turnstile token, unknown email, malformed input) — an
+ * attacker probing this endpoint can't learn which emails have accounts.
+ */
+const GENERIC_RESPONSE = {
+	message: 'If an account exists for that email, a verification code has been sent.'
+}
+
+function generateCode(): string {
+	return crypto.randomInt(0, 1_000_000).toString().padStart(6, '0')
+}
+
+export const requestCode = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const { email, turnstileToken } = request.body as { email?: string; turnstileToken?: string }
+
+		if (!email || !turnstileToken) {
+			response.status(400).json({
+				error: { code: 'MISSING_FIELDS', message: 'email and turnstileToken are required' }
+			})
+			return
+		}
+
+		const ip = request.ip ?? 'unknown'
+
+		if (await isRateLimited(email, ip)) {
+			response.json(GENERIC_RESPONSE)
+			return
+		}
+
+		await recordAttempt(email, ip)
+
+		const turnstileValid = await verifyTurnstileToken(turnstileToken, request.ip)
+
+		if (!turnstileValid) {
+			response.json(GENERIC_RESPONSE)
+			return
+		}
+
+		const user = await User.findOne({ email })
+
+		if (user) {
+			const code = generateCode()
+			const codeHash = await hashValue(code)
+
+			await AuthCode.create({
+				email,
+				codeHash,
+				expiresAt: new Date(Date.now() + CODE_TTL_MINUTES * 60 * 1000)
+			})
+
+			// Delivery (email provider) is a separate, not-yet-made infra
+			// decision — code is persisted and ready to send once that's wired up.
+		}
+
+		response.json(GENERIC_RESPONSE)
+	} catch (error) {
+		next(error)
+	}
+}

--- a/server/database/models/AuthCode.ts
+++ b/server/database/models/AuthCode.ts
@@ -1,0 +1,24 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface AuthCodeDocument extends mongoose.Document {
+	email: string
+	// Never stored raw — see server/lib/hash.ts.
+	codeHash: string
+	used: boolean
+	expiresAt: Date
+	createdAt: Date
+}
+
+const authCodeSchema = new Schema<AuthCodeDocument>({
+	email: { type: String, required: true },
+	codeHash: { type: String, required: true },
+	used: { type: Boolean, default: false },
+	expiresAt: { type: Date, required: true },
+	createdAt: { type: Date, default: Date.now }
+})
+
+// TTL index: Mongo drops the document itself once expiresAt passes, so
+// expired codes don't need a separate cleanup job.
+authCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+
+export const AuthCode = mongoose.models.AuthCode || mongoose.model<AuthCodeDocument>('AuthCode', authCodeSchema)

--- a/server/database/models/RateLimitEvent.ts
+++ b/server/database/models/RateLimitEvent.ts
@@ -1,0 +1,22 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface RateLimitEventDocument extends mongoose.Document {
+	email: string
+	ip: string
+	createdAt: Date
+}
+
+const rateLimitEventSchema = new Schema<RateLimitEventDocument>({
+	email: { type: String, required: true },
+	ip: { type: String, required: true },
+	createdAt: { type: Date, default: Date.now }
+})
+
+rateLimitEventSchema.index({ email: 1, createdAt: 1 })
+rateLimitEventSchema.index({ ip: 1, createdAt: 1 })
+// TTL matches the longest window a caller checks against (see server/lib/rateLimit.ts)
+// so nothing needs a separate cleanup job.
+rateLimitEventSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 })
+
+export const RateLimitEvent =
+	mongoose.models.RateLimitEvent || mongoose.model<RateLimitEventDocument>('RateLimitEvent', rateLimitEventSchema)

--- a/server/database/models/User.ts
+++ b/server/database/models/User.ts
@@ -1,0 +1,26 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface UserDocument extends mongoose.Document {
+	username: string
+	email: string
+	honestyScore: number
+	// Set once a later phone-verification flow (SMS send/verify) completes.
+	// Not built yet — this only reserves the field so the schema doesn't
+	// need a migration when that phase lands.
+	isPhoneVerified: boolean
+	// Hashed via server/lib/hash.ts — raw phone numbers are never stored,
+	// per the data-minimization gate (see server/serializers/README.md).
+	phoneNumberHash: string | null
+	createdAt: Date
+}
+
+const userSchema = new Schema<UserDocument>({
+	username: { type: String, required: true, unique: true },
+	email: { type: String, required: true, unique: true },
+	honestyScore: { type: Number, default: 0 },
+	isPhoneVerified: { type: Boolean, default: false },
+	phoneNumberHash: { type: String, default: null },
+	createdAt: { type: Date, default: Date.now }
+})
+
+export const User = mongoose.models.User || mongoose.model<UserDocument>('User', userSchema)

--- a/server/lib/hash.ts
+++ b/server/lib/hash.ts
@@ -1,0 +1,46 @@
+import crypto from 'crypto'
+
+/*
+ * Shared one-way hashing for values that must never be stored or logged raw
+ * (auth codes, phone numbers). Uses scrypt with a per-value random salt plus
+ * a server-side pepper so a DB leak alone isn't enough to recover inputs.
+ */
+const pepper = process.env.HASH_PEPPER || ''
+
+export async function hashValue(value: string): Promise<string> {
+	const salt = crypto.randomBytes(16).toString('hex')
+
+	const derivedKey = await new Promise<Buffer>((resolve, reject) => {
+		crypto.scrypt(`${value}${pepper}`, salt, 64, (error, key) => {
+			if (error) {
+				reject(error)
+			} else {
+				resolve(key)
+			}
+		})
+	})
+
+	return `${salt}:${derivedKey.toString('hex')}`
+}
+
+export async function verifyHash(value: string, stored: string): Promise<boolean> {
+	const [salt, hash] = stored.split(':')
+
+	if (!salt || !hash) {
+		return false
+	}
+
+	const derivedKey = await new Promise<Buffer>((resolve, reject) => {
+		crypto.scrypt(`${value}${pepper}`, salt, 64, (error, key) => {
+			if (error) {
+				reject(error)
+			} else {
+				resolve(key)
+			}
+		})
+	})
+
+	const hashBuffer = Buffer.from(hash, 'hex')
+
+	return hashBuffer.length === derivedKey.length && crypto.timingSafeEqual(hashBuffer, derivedKey)
+}

--- a/server/lib/rateLimit.ts
+++ b/server/lib/rateLimit.ts
@@ -1,0 +1,29 @@
+import { RateLimitEvent } from '../database/models/RateLimitEvent'
+
+const EMAIL_LIMIT = 5
+const EMAIL_WINDOW_MS = 15 * 60 * 1000
+const IP_LIMIT = 20
+const IP_WINDOW_MS = 60 * 60 * 1000
+
+/*
+ * Two independent windows: per-email catches repeated probing of one target,
+ * per-IP catches one source rotating through many target emails. Either one
+ * tripping is enough to reject — the caller must not distinguish which.
+ */
+export async function isRateLimited(email: string, ip: string): Promise<boolean> {
+	const now = Date.now()
+
+	const [emailCount, ipCount] = await Promise.all([
+		RateLimitEvent.countDocuments({ email, createdAt: { $gte: new Date(now - EMAIL_WINDOW_MS) } }),
+		RateLimitEvent.countDocuments({ ip, createdAt: { $gte: new Date(now - IP_WINDOW_MS) } })
+	])
+
+	return emailCount >= EMAIL_LIMIT || ipCount >= IP_LIMIT
+}
+
+// Recorded for every request that reaches this point (valid shape, past the
+// rate-limit check itself) — regardless of whether Turnstile or the email
+// lookup subsequently succeeds, so probing attempts still count.
+export async function recordAttempt(email: string, ip: string): Promise<void> {
+	await RateLimitEvent.create({ email, ip })
+}

--- a/server/lib/turnstile.ts
+++ b/server/lib/turnstile.ts
@@ -1,0 +1,38 @@
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+/*
+ * Verifies a Cloudflare Turnstile token server-side before any code is
+ * generated. Fails closed: network errors or a missing secret are treated as
+ * verification failure, never as a bypass.
+ */
+export async function verifyTurnstileToken(token: string | undefined, remoteIp?: string): Promise<boolean> {
+	const secret = process.env.TURNSTILE_SECRET_KEY
+
+	if (!secret || !token) {
+		return false
+	}
+
+	try {
+		const body = new URLSearchParams({ secret, response: token })
+
+		if (remoteIp) {
+			body.set('remoteip', remoteIp)
+		}
+
+		const response = await fetch(SITEVERIFY_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body
+		})
+
+		if (!response.ok) {
+			return false
+		}
+
+		const result = (await response.json()) as { success: boolean }
+
+		return result.success === true
+	} catch {
+		return false
+	}
+}

--- a/server/routes/authRoutes.ts
+++ b/server/routes/authRoutes.ts
@@ -1,0 +1,12 @@
+import express from 'express'
+import { requestCode } from '../actions/auth'
+
+const authRoutes = () => {
+	const router = express.Router()
+
+	router.post('/request-code', requestCode)
+
+	return router
+}
+
+export default authRoutes

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,10 +1,12 @@
 import express from 'express'
 import {getPopular} from '../actions'
+import authRoutes from './authRoutes'
 import movieRoutes from './movieRoutes'
 
 const router = express.Router()
 
 router.use('/movies', movieRoutes())
+router.use('/auth', authRoutes())
 router.get('/', getPopular)
 
 export default router

--- a/server/serializers/README.md
+++ b/server/serializers/README.md
@@ -15,4 +15,8 @@ TrailerOpinion, Review, Vote, etc. in Phase 2+):
 - Route handlers call the DTO before `response.send()` — raw model documents
   and raw upstream API payloads must not be sent directly.
 
-Planned example: `UserPublicDTO { username, honestyScore, isLowTrust }`.
+Example (built in Phase 3): `UserPublicDTO { username, honestyScore, isLowTrust, isPhoneVerified }`
+— `isPhoneVerified` feeds a future "Verified" badge the same way `isLowTrust`
+feeds the low-trust badge (opposite signal, same DTO-exposure pattern).
+`phoneNumberHash` never appears here — like auth-code hashes, it's not
+something the client needs.

--- a/server/serializers/tests/users.test.js
+++ b/server/serializers/tests/users.test.js
@@ -1,0 +1,26 @@
+import { toUserPublicDTO } from '../users'
+
+const user = {
+	username: 'critic7',
+	email: 'critic7@example.com',
+	honestyScore: 45,
+	isPhoneVerified: true,
+	phoneNumberHash: 'salt:hash'
+}
+
+describe('user serializer allowlist', () => {
+	test('public DTO drops email and phoneNumberHash', () => {
+		const dto = toUserPublicDTO(user)
+
+		expect(Object.keys(dto).sort()).toEqual(['honestyScore', 'isLowTrust', 'isPhoneVerified', 'username'])
+		expect(dto).not.toHaveProperty('email')
+		expect(dto).not.toHaveProperty('phoneNumberHash')
+	})
+
+	test('isLowTrust flips opposite isPhoneVerified pattern: low score -> true', () => {
+		const lowTrustUser = { ...user, honestyScore: 10 }
+
+		expect(toUserPublicDTO(lowTrustUser).isLowTrust).toBe(true)
+		expect(toUserPublicDTO(user).isLowTrust).toBe(false)
+	})
+})

--- a/server/serializers/users.ts
+++ b/server/serializers/users.ts
@@ -1,0 +1,21 @@
+import { UserDocument } from '../database/models/User'
+
+export interface UserPublicDTO {
+	username: string
+	honestyScore: number
+	isLowTrust: boolean
+	isPhoneVerified: boolean
+}
+
+// Placeholder until the Config model (docs/plan) exists — mirrors its
+// planned lowTrustBadgeThreshold default of 30.
+const LOW_TRUST_THRESHOLD = 30
+
+export function toUserPublicDTO(user: UserDocument): UserPublicDTO {
+	return {
+		username: user.username,
+		honestyScore: user.honestyScore,
+		isLowTrust: user.honestyScore < LOW_TRUST_THRESHOLD,
+		isPhoneVerified: user.isPhoneVerified
+	}
+}


### PR DESCRIPTION
…elds, UserPublicDTO

## What

<!-- Summary of the change -->

## Data Minimization & Leak Prevention gate

Required for every PR touching an API response, logging, or error handling
(see `docs/plan/criticseven-modernization-plan.md`, Standing Requirement):

- [ ] Every API response goes through an explicit-allowlist DTO in `server/serializers/` — no raw model documents or upstream payloads sent to the client, no select-minus/denylist shaping
- [ ] No email, password/auth-code hashes, raw `HonestyLog` entries, or internal `_id` (where a public id suffices) in any response
- [ ] Error responses: generic message + error code only in production; full detail stays in server logs (central `errorHandler`, no per-route `res.status(500).send(error.message)`)
- [ ] No `console.log`/`console.error` of request bodies, user objects, auth codes, or raw upstream errors (axios errors embed the TMDB `api_key`)
- [ ] Request logging (morgan) does not log bodies; `/auth/*` URLs are logged without query strings

Auth routes only (Phase 3+):

- [ ] `POST /auth/verify-code` response never echoes the submitted or stored code
- [ ] `POST /auth/request-code` returns the identical response whether or not the email exists (no account enumeration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added passwordless sign-in code requests via a new authentication endpoint.
  - Verification codes expire after 10 minutes and are protected with secure hashing.
  - Added safeguards against repeated requests, automated abuse, and account enumeration.
  - Added public user profiles with usernames, honesty scores, phone verification status, and trust indicators.

- **Documentation**
  - Updated user profile documentation to clarify which sensitive fields remain private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->