### PR TITLE
phase3/auth-verify: POST /auth/verify-code, RR8 session cookie, auth …

### DIFF
--- a/client/src/routes/auth.verify-code.tsx
+++ b/client/src/routes/auth.verify-code.tsx
@@ -1,0 +1,40 @@
+import { sessionStorage } from '../session.server'
+import type { Route } from './+types/auth.verify-code'
+
+const API_URL = process.env.API_URL ?? 'http://localhost:5000'
+
+const GENERIC_FAILURE = {
+	error: { code: 'INVALID_CODE', message: 'Invalid or expired code.' }
+}
+
+interface VerifyCodeSuccess {
+	valid: true
+	userId: string
+	username: string
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const body = await request.json()
+
+	const upstream = await fetch(`${API_URL}/auth/verify-code`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	})
+
+	if (!upstream.ok) {
+		return Response.json(GENERIC_FAILURE, { status: 401 })
+	}
+
+	const result = (await upstream.json()) as VerifyCodeSuccess
+
+	const session = await sessionStorage.getSession()
+
+	session.set('userId', result.userId)
+	session.set('username', result.username)
+
+	return Response.json(
+		{ valid: true },
+		{ headers: { 'Set-Cookie': await sessionStorage.commitSession(session) } }
+	)
+}

--- a/client/src/session.server.ts
+++ b/client/src/session.server.ts
@@ -1,0 +1,47 @@
+import { createCookieSessionStorage } from 'react-router'
+
+/*
+ * `createCookieSessionStorage` lives in the core `react-router` package, not
+ * `@react-router/node` — the Remix/React Router merge moved the (framework-
+ * agnostic, Web Crypto based) session utilities up to `react-router` itself.
+ * `@react-router/node` now only carries Node-platform-specific pieces
+ * (createFileSessionStorage, the Node http request-listener adapter), so
+ * there's nothing to import from there for a cookie session.
+ */
+
+export interface SessionData {
+	userId: string
+	username: string
+}
+
+const sessionSecret = process.env.SESSION_SECRET || 'dev-insecure-secret-change-me'
+
+export const sessionStorage = createCookieSessionStorage<SessionData>({
+	cookie: {
+		name: '__session',
+		httpOnly: true,
+		secure: process.env.NODE_ENV === 'production',
+		sameSite: 'lax',
+		secrets: [sessionSecret],
+		path: '/'
+	}
+})
+
+export async function getSession(request: Request) {
+	return sessionStorage.getSession(request.headers.get('Cookie'))
+}
+
+// Reusable gate for future routes (Phase 5: opinion/review/vote creation) —
+// call at the top of a loader/action and use the returned identity, or let
+// the thrown 401 propagate to the route's error boundary.
+export async function requireSession(request: Request): Promise<SessionData> {
+	const session = await getSession(request)
+	const userId = session.get('userId')
+	const username = session.get('username')
+
+	if (!userId || !username) {
+		throw new Response('Unauthorized', { status: 401 })
+	}
+
+	return { userId, username }
+}

--- a/package.json
+++ b/package.json
@@ -61,10 +61,13 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
+    "@types/supertest": "7.2.0",
     "jest": "30.4.2",
+    "mongodb-memory-server": "^11.2.0",
     "nodemon": "3.1.14",
     "prettier": "2.0.2",
     "rimraf": "3.0.2",
+    "supertest": "^7.2.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@types/node':
         specifier: ^26.1.0
         version: 26.1.0
+      '@types/supertest':
+        specifier: 7.2.0
+        version: 7.2.0
       babel-jest:
         specifier: 30.4.1
         version: 30.4.1(@babel/core@7.29.7)
@@ -99,6 +102,9 @@ importers:
       jest:
         specifier: 30.4.2
         version: 30.4.2(@types/node@26.1.0)
+      mongodb-memory-server:
+        specifier: ^11.2.0
+        version: 11.2.0
       nodemon:
         specifier: 3.1.14
         version: 3.1.14
@@ -108,6 +114,9 @@ importers:
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1189,6 +1198,13 @@ packages:
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1435,6 +1451,9 @@ packages:
     peerDependencies:
       '@types/express': '*'
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1461,6 +1480,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -1500,11 +1522,20 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/superagent@8.1.10':
+    resolution: {integrity: sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==}
+
+  '@types/supertest@7.2.0':
+    resolution: {integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==}
+
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1716,6 +1747,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1796,9 +1831,15 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1809,6 +1850,14 @@ packages:
 
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1865,6 +1914,47 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.3:
+    resolution: {integrity: sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.3:
+    resolution: {integrity: sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.1:
+    resolution: {integrity: sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
+
   baseline-browser-mapping@2.10.42:
     resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
@@ -1911,6 +2001,10 @@ packages:
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
+
+  bson@7.3.1:
+    resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
+    engines: {node: '>=20.19.0'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2023,6 +2117,9 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -2078,6 +2175,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -2175,6 +2275,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2372,6 +2475,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2402,11 +2508,17 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -2439,6 +2551,10 @@ packages:
   find-cache-dir@2.1.0:
     resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
     engines: {node: '>=6'}
+
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
 
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -2479,6 +2595,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2642,6 +2762,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3102,6 +3226,10 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -3159,6 +3287,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3181,6 +3314,18 @@ packages:
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server-core@11.2.0:
+    resolution: {integrity: sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server@11.2.0:
+    resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
+    engines: {node: '>=20.19.0'}
+
   mongodb@6.20.0:
     resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
     engines: {node: '>=16.20.1'}
@@ -3192,6 +3337,33 @@ packages:
       mongodb-client-encryption: '>=6.0.0 <7'
       snappy: ^7.3.2
       socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongodb@7.4.0:
+    resolution: {integrity: sha512-giySkkdYiwoBFo/oCc8nzov3xOYZ/sB8OpAYk5GINRLEjVw0LDsm8xgQL0XMTyU4extQlDZjhdUr1ZEwKFaazw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
@@ -3254,6 +3426,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
 
   node-environment-flags@1.0.6:
     resolution: {integrity: sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==}
@@ -3425,6 +3601,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3896,6 +4075,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -3961,6 +4143,14 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
 
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -3992,9 +4182,18 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -4034,6 +4233,9 @@ packages:
 
   tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4303,6 +4505,10 @@ packages:
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -5560,6 +5766,12 @@ snapshots:
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5764,6 +5976,8 @@ snapshots:
     dependencies:
       '@types/express': 4.17.25
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5797,6 +6011,8 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
 
@@ -5839,9 +6055,25 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/superagent@8.1.10':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 26.1.0
+      form-data: 4.0.6
+
+  '@types/supertest@7.2.0':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.10
+
   '@types/webidl-conversions@7.0.3': {}
 
   '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
+  '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
@@ -6036,6 +6268,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6146,7 +6380,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asap@2.0.6: {}
+
   async-function@1.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
 
   asynckit@0.4.0: {}
 
@@ -6163,6 +6403,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  b4a@1.8.1: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -6261,6 +6503,39 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.3:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.0.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.3: {}
+
+  bare-path@3.0.1:
+    dependencies:
+      bare-os: 3.9.3
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.0.1
+
   baseline-browser-mapping@2.10.42: {}
 
   basic-auth@2.0.1:
@@ -6330,6 +6605,8 @@ snapshots:
       node-int64: 0.4.0
 
   bson@6.10.4: {}
+
+  bson@7.3.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6439,6 +6716,8 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  component-emitter@1.3.1: {}
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.52.0
@@ -6495,6 +6774,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   core-js-compat@3.49.0:
     dependencies:
@@ -6573,6 +6854,11 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   doctrine@2.1.0:
     dependencies:
@@ -6880,6 +7166,12 @@ snapshots:
 
   etag@1.8.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -6978,9 +7270,13 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fb-watchman@2.0.2:
     dependencies:
@@ -7027,6 +7323,12 @@ snapshots:
       make-dir: 2.1.0
       pkg-dir: 3.0.0
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
   find-up@3.0.0:
     dependencies:
       locate-path: 3.0.0
@@ -7068,6 +7370,12 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -7226,6 +7534,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -7859,6 +8174,10 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
@@ -7897,6 +8216,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@2.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   minimatch@10.2.5:
@@ -7918,11 +8239,66 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb-memory-server-core@11.2.0:
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3(supports-color@5.5.0)
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
+      mongodb: 7.4.0
+      new-find-package-json: 2.0.0
+      semver: 7.8.5
+      tar-stream: 3.2.0
+      tslib: 2.8.1
+      yauzl: 3.4.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server@11.2.0:
+    dependencies:
+      mongodb-memory-server-core: 11.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
   mongodb@6.20.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
+
+  mongodb@7.4.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.12
+      bson: 7.3.1
+      mongodb-connection-string-url: 7.0.1
 
   mongoose@8.24.1:
     dependencies:
@@ -7976,6 +8352,12 @@ snapshots:
   negotiator@0.6.4: {}
 
   negotiator@1.0.0: {}
+
+  new-find-package-json@2.0.0:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
 
   node-environment-flags@1.0.6:
     dependencies:
@@ -8162,6 +8544,8 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -8689,6 +9073,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -8779,6 +9172,28 @@ snapshots:
     dependencies:
       postcss: 8.5.16
 
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.6
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.15.3
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -8805,11 +9220,35 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinyglobby@0.2.17:
     dependencies:
@@ -8839,6 +9278,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.5.3: {}
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -9145,6 +9586,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/server/actions/auth.ts
+++ b/server/actions/auth.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 import { NextFunction, Request, Response } from 'express'
 import { AuthCode } from '../database/models/AuthCode'
 import { User } from '../database/models/User'
-import { hashValue } from '../lib/hash'
+import { hashValue, verifyHash } from '../lib/hash'
 import { isRateLimited, recordAttempt } from '../lib/rateLimit'
 import { verifyTurnstileToken } from '../lib/turnstile'
 
@@ -10,11 +10,20 @@ const CODE_TTL_MINUTES = 10
 
 /*
  * Always resolves to the same generic body regardless of why a code wasn't
- * actually sent (bad Turnstile token, unknown email, malformed input) — an
- * attacker probing this endpoint can't learn which emails have accounts.
+ * actually sent (bad Turnstile token, unknown email, malformed input, rate
+ * limited) — an attacker probing this endpoint can't learn which emails have
+ * accounts.
  */
-const GENERIC_RESPONSE = {
+const GENERIC_REQUEST_RESPONSE = {
 	message: 'If an account exists for that email, a verification code has been sent.'
+}
+
+/*
+ * Same principle for verification: expired, wrong, already-used, unknown-email
+ * and rate-limited all look identical to the caller.
+ */
+const GENERIC_VERIFY_FAILURE = {
+	error: { code: 'INVALID_CODE', message: 'Invalid or expired code.' }
 }
 
 function generateCode(): string {
@@ -34,17 +43,17 @@ export const requestCode = async(request: Request, response: Response, next: Nex
 
 		const ip = request.ip ?? 'unknown'
 
-		if (await isRateLimited(email, ip)) {
-			response.json(GENERIC_RESPONSE)
+		if (await isRateLimited('request-code', email, ip)) {
+			response.json(GENERIC_REQUEST_RESPONSE)
 			return
 		}
 
-		await recordAttempt(email, ip)
+		await recordAttempt('request-code', email, ip)
 
 		const turnstileValid = await verifyTurnstileToken(turnstileToken, request.ip)
 
 		if (!turnstileValid) {
-			response.json(GENERIC_RESPONSE)
+			response.json(GENERIC_REQUEST_RESPONSE)
 			return
 		}
 
@@ -64,7 +73,70 @@ export const requestCode = async(request: Request, response: Response, next: Nex
 			// decision — code is persisted and ready to send once that's wired up.
 		}
 
-		response.json(GENERIC_RESPONSE)
+		response.json(GENERIC_REQUEST_RESPONSE)
+	} catch (error) {
+		next(error)
+	}
+}
+
+export const verifyCode = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const { email, code } = request.body as { email?: string; code?: string }
+
+		if (!email || !code) {
+			response.status(400).json({
+				error: { code: 'MISSING_FIELDS', message: 'email and code are required' }
+			})
+			return
+		}
+
+		const ip = request.ip ?? 'unknown'
+
+		// Same 5/15min-per-email budget as request-code, own scope so the two
+		// don't share a bucket — recorded unconditionally below so repeated
+		// wrong guesses (not just eventual successes) count against it.
+		if (await isRateLimited('verify-code', email, ip)) {
+			response.status(401).json(GENERIC_VERIFY_FAILURE)
+			return
+		}
+
+		await recordAttempt('verify-code', email, ip)
+
+		// Bounded by the request-code limiter (at most 5 active codes per
+		// email), so checking each candidate's hash here is cheap.
+		const candidates = await AuthCode.find({
+			email,
+			used: false,
+			expiresAt: { $gt: new Date() }
+		})
+
+		let matchedCandidateId: string | null = null
+
+		for (const candidate of candidates) {
+			if (await verifyHash(code, candidate.codeHash)) {
+				matchedCandidateId = candidate.id
+				break
+			}
+		}
+
+		if (!matchedCandidateId) {
+			response.status(401).json(GENERIC_VERIFY_FAILURE)
+			return
+		}
+
+		const user = await User.findOne({ email })
+
+		if (!user) {
+			response.status(401).json(GENERIC_VERIFY_FAILURE)
+			return
+		}
+
+		// Marked used rather than deleted — keeps the reuse check (`used: false`
+		// above) authoritative without racing the TTL sweep, and leaves a trail
+		// until expiry cleans it up.
+		await AuthCode.updateOne({ _id: matchedCandidateId }, { used: true })
+
+		response.status(200).json({ valid: true, userId: user.id, username: user.username })
 	} catch (error) {
 		next(error)
 	}

--- a/server/actions/tests/auth.test.ts
+++ b/server/actions/tests/auth.test.ts
@@ -1,0 +1,127 @@
+import express from 'express'
+import request from 'supertest'
+import { AuthCode } from '../../database/models/AuthCode'
+import { User } from '../../database/models/User'
+import { hashValue } from '../../lib/hash'
+import { clearTestDb, connectTestDb, disconnectTestDb } from '../../testSupport/db'
+import authRoutes from '../../routes/authRoutes'
+
+const app = express()
+
+app.use(express.json())
+app.use('/auth', authRoutes())
+
+const EMAIL = 'critic7@example.com'
+const CODE = '123456'
+
+const GENERIC_FAILURE = {
+	error: { code: 'INVALID_CODE', message: 'Invalid or expired code.' }
+}
+
+async function seedUser() {
+	await User.create({ username: 'critic7', email: EMAIL, honestyScore: 50 })
+}
+
+async function seedCode(overrides: Partial<{ used: boolean; expiresAt: Date }> = {}) {
+	const codeHash = await hashValue(CODE)
+
+	return AuthCode.create({
+		email: EMAIL,
+		codeHash,
+		used: overrides.used ?? false,
+		expiresAt: overrides.expiresAt ?? new Date(Date.now() + 10 * 60 * 1000)
+	})
+}
+
+beforeAll(async() => {
+	await connectTestDb()
+})
+
+afterAll(async() => {
+	await disconnectTestDb()
+})
+
+afterEach(async() => {
+	await clearTestDb()
+})
+
+describe('POST /auth/verify-code', () => {
+	test('valid code succeeds and returns the user identity', async() => {
+		await seedUser()
+		await seedCode()
+
+		const response = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+
+		expect(response.status).toBe(200)
+		expect(response.body).toEqual({ valid: true, userId: expect.any(String), username: 'critic7' })
+	})
+
+	test('single-use: a second attempt with the same code fails', async() => {
+		await seedUser()
+		await seedCode()
+
+		const first = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+		const second = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+
+		expect(first.status).toBe(200)
+		expect(second.status).toBe(401)
+		expect(second.body).toEqual(GENERIC_FAILURE)
+	})
+
+	test('expiry: an expired code is rejected', async() => {
+		await seedUser()
+		await seedCode({ expiresAt: new Date(Date.now() - 1000) })
+
+		const response = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+
+		expect(response.status).toBe(401)
+		expect(response.body).toEqual(GENERIC_FAILURE)
+	})
+
+	test('an already-used code is rejected even before expiry', async() => {
+		await seedUser()
+		await seedCode({ used: true })
+
+		const response = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+
+		expect(response.status).toBe(401)
+		expect(response.body).toEqual(GENERIC_FAILURE)
+	})
+
+	test('wrong code, unknown email, and expired code all return the identical response', async() => {
+		await seedUser()
+		await seedCode()
+
+		const wrongCode = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: '000000' })
+		const unknownEmail = await request(app)
+			.post('/auth/verify-code')
+			.send({ email: 'nobody@example.com', code: CODE })
+
+		expect(wrongCode.status).toBe(unknownEmail.status)
+		expect(wrongCode.body).toEqual(unknownEmail.body)
+		expect(wrongCode.body).toEqual(GENERIC_FAILURE)
+	})
+
+	test('rate limit: a 6th attempt within 15 minutes is rejected even with the correct code', async() => {
+		await seedUser()
+		await seedCode()
+
+		for (let i = 0; i < 5; i += 1) {
+			const attempt = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: '000000' })
+
+			expect(attempt.status).toBe(401)
+		}
+
+		const sixthAttempt = await request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+
+		expect(sixthAttempt.status).toBe(401)
+		expect(sixthAttempt.body).toEqual(GENERIC_FAILURE)
+	})
+
+	test('missing fields return a distinct 400, not the generic-failure body', async() => {
+		const response = await request(app).post('/auth/verify-code').send({ email: EMAIL })
+
+		expect(response.status).toBe(400)
+		expect(response.body).not.toEqual(GENERIC_FAILURE)
+	})
+})

--- a/server/database/models/RateLimitEvent.ts
+++ b/server/database/models/RateLimitEvent.ts
@@ -1,19 +1,23 @@
 import mongoose, { Schema } from 'mongoose'
 
 export interface RateLimitEventDocument extends mongoose.Document {
+	// Separates budgets per endpoint (e.g. 'request-code', 'verify-code') so
+	// exhausting one doesn't starve the other for the same user.
+	scope: string
 	email: string
 	ip: string
 	createdAt: Date
 }
 
 const rateLimitEventSchema = new Schema<RateLimitEventDocument>({
+	scope: { type: String, required: true },
 	email: { type: String, required: true },
 	ip: { type: String, required: true },
 	createdAt: { type: Date, default: Date.now }
 })
 
-rateLimitEventSchema.index({ email: 1, createdAt: 1 })
-rateLimitEventSchema.index({ ip: 1, createdAt: 1 })
+rateLimitEventSchema.index({ scope: 1, email: 1, createdAt: 1 })
+rateLimitEventSchema.index({ scope: 1, ip: 1, createdAt: 1 })
 // TTL matches the longest window a caller checks against (see server/lib/rateLimit.ts)
 // so nothing needs a separate cleanup job.
 rateLimitEventSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 })

--- a/server/lib/rateLimit.ts
+++ b/server/lib/rateLimit.ts
@@ -9,21 +9,22 @@ const IP_WINDOW_MS = 60 * 60 * 1000
  * Two independent windows: per-email catches repeated probing of one target,
  * per-IP catches one source rotating through many target emails. Either one
  * tripping is enough to reject — the caller must not distinguish which.
+ * `scope` keeps request-code and verify-code budgets from starving each other.
  */
-export async function isRateLimited(email: string, ip: string): Promise<boolean> {
+export async function isRateLimited(scope: string, email: string, ip: string): Promise<boolean> {
 	const now = Date.now()
 
 	const [emailCount, ipCount] = await Promise.all([
-		RateLimitEvent.countDocuments({ email, createdAt: { $gte: new Date(now - EMAIL_WINDOW_MS) } }),
-		RateLimitEvent.countDocuments({ ip, createdAt: { $gte: new Date(now - IP_WINDOW_MS) } })
+		RateLimitEvent.countDocuments({ scope, email, createdAt: { $gte: new Date(now - EMAIL_WINDOW_MS) } }),
+		RateLimitEvent.countDocuments({ scope, ip, createdAt: { $gte: new Date(now - IP_WINDOW_MS) } })
 	])
 
 	return emailCount >= EMAIL_LIMIT || ipCount >= IP_LIMIT
 }
 
 // Recorded for every request that reaches this point (valid shape, past the
-// rate-limit check itself) — regardless of whether Turnstile or the email
-// lookup subsequently succeeds, so probing attempts still count.
-export async function recordAttempt(email: string, ip: string): Promise<void> {
-	await RateLimitEvent.create({ email, ip })
+// rate-limit check itself) — regardless of whether the subsequent check
+// (Turnstile, code match) succeeds, so probing attempts still count.
+export async function recordAttempt(scope: string, email: string, ip: string): Promise<void> {
+	await RateLimitEvent.create({ scope, email, ip })
 }

--- a/server/routes/authRoutes.ts
+++ b/server/routes/authRoutes.ts
@@ -1,10 +1,11 @@
 import express from 'express'
-import { requestCode } from '../actions/auth'
+import { requestCode, verifyCode } from '../actions/auth'
 
 const authRoutes = () => {
 	const router = express.Router()
 
 	router.post('/request-code', requestCode)
+	router.post('/verify-code', verifyCode)
 
 	return router
 }

--- a/server/testSupport/db.ts
+++ b/server/testSupport/db.ts
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+
+let mongod: MongoMemoryServer
+
+export async function connectTestDb(): Promise<void> {
+	mongod = await MongoMemoryServer.create()
+	await mongoose.connect(mongod.getUri())
+}
+
+export async function disconnectTestDb(): Promise<void> {
+	await mongoose.disconnect()
+	await mongod.stop()
+}
+
+export async function clearTestDb(): Promise<void> {
+	const { collections } = mongoose.connection
+
+	await Promise.all(Object.values(collections).map(collection => collection.deleteMany({})))
+}


### PR DESCRIPTION
…tests

- Add verifyCode handler: matches AuthCode by email against unused, unexpired codes via verifyHash, marks matched code used:true. All failure modes (wrong code, expired, used, unknown email, rate-limited) return identical INVALID_CODE/401 to avoid leaking which case occurred; malformed input is a distinct 400.
- Add scope field to RateLimitEvent/rateLimit so request-code and verify-code track independent budgets (5/15min per email, 20/hour per IP) - otherwise requesting a code would eat into the budget for submitting it.
- Add client/src/session.server.ts: requireSession() cookie-session gate for future authenticated loaders/actions, using createCookieSessionStorage from react-router (moved out of @react-router/node in v8).
- Add client/src/routes/auth.verify-code.tsx: RR8 resource route (action-only) that forwards to the Express endpoint and commits the session cookie on success.
- Add server/actions/tests/auth.test.ts (7 cases) and server/testSupport/db.ts using mongodb-memory-server + supertest - first automated coverage for the auth endpoints; request-code was previously verified manually only.

## What

<!-- Summary of the change -->

## Data Minimization & Leak Prevention gate

Required for every PR touching an API response, logging, or error handling
(see `docs/plan/criticseven-modernization-plan.md`, Standing Requirement):

- [ ] Every API response goes through an explicit-allowlist DTO in `server/serializers/` — no raw model documents or upstream payloads sent to the client, no select-minus/denylist shaping
- [ ] No email, password/auth-code hashes, raw `HonestyLog` entries, or internal `_id` (where a public id suffices) in any response
- [ ] Error responses: generic message + error code only in production; full detail stays in server logs (central `errorHandler`, no per-route `res.status(500).send(error.message)`)
- [ ] No `console.log`/`console.error` of request bodies, user objects, auth codes, or raw upstream errors (axios errors embed the TMDB `api_key`)
- [ ] Request logging (morgan) does not log bodies; `/auth/*` URLs are logged without query strings

Auth routes only (Phase 3+):

- [ ] `POST /auth/verify-code` response never echoes the submitted or stored code
- [ ] `POST /auth/request-code` returns the identical response whether or not the email exists (no account enumeration)
