### PR TITLE
phase3.5: fix auth-code TOCTOU race (atomic findOneAndUpdate claim), …

### DIFF
--- a/client/src/session.server.ts
+++ b/client/src/session.server.ts
@@ -14,6 +14,14 @@ export interface SessionData {
 	username: string
 }
 
+// Fail closed like the Turnstile check (server/lib/turnstile.ts): a missing
+// secret in production must crash the process, not silently sign session
+// cookies with a value that sits in source control — that would let anyone
+// who has read the repo forge a valid session for any userId/username.
+if (process.env.NODE_ENV === 'production' && !process.env.SESSION_SECRET) {
+	throw new Error('SESSION_SECRET must be set in production')
+}
+
 const sessionSecret = process.env.SESSION_SECRET || 'dev-insecure-secret-change-me'
 
 export const sessionStorage = createCookieSessionStorage<SessionData>({

--- a/server/actions/auth.ts
+++ b/server/actions/auth.ts
@@ -124,17 +124,29 @@ export const verifyCode = async(request: Request, response: Response, next: Next
 			return
 		}
 
+		// Atomic claim: the match above only proves the candidate *was* unused
+		// at read time. Two concurrent requests can both match the same
+		// candidate before either writes `used: true`, so the actual single-use
+		// guarantee has to be this conditional update, not the find above.
+		// Only the request that flips `used: false -> true` gets a document
+		// back; a second, concurrent request loses the race and matchedCode
+		// comes back null.
+		const matchedCode = await AuthCode.findOneAndUpdate(
+			{ _id: matchedCandidateId, used: false },
+			{ used: true }
+		)
+
+		if (!matchedCode) {
+			response.status(401).json(GENERIC_VERIFY_FAILURE)
+			return
+		}
+
 		const user = await User.findOne({ email })
 
 		if (!user) {
 			response.status(401).json(GENERIC_VERIFY_FAILURE)
 			return
 		}
-
-		// Marked used rather than deleted — keeps the reuse check (`used: false`
-		// above) authoritative without racing the TTL sweep, and leaves a trail
-		// until expiry cleans it up.
-		await AuthCode.updateOne({ _id: matchedCandidateId }, { used: true })
 
 		response.status(200).json({ valid: true, userId: user.id, username: user.username })
 	} catch (error) {

--- a/server/actions/tests/auth.test.ts
+++ b/server/actions/tests/auth.test.ts
@@ -118,6 +118,20 @@ describe('POST /auth/verify-code', () => {
 		expect(sixthAttempt.body).toEqual(GENERIC_FAILURE)
 	})
 
+	test('race condition: two concurrent requests with the same valid code, only one succeeds', async() => {
+		await seedUser()
+		await seedCode()
+
+		const [first, second] = await Promise.all([
+			request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE }),
+			request(app).post('/auth/verify-code').send({ email: EMAIL, code: CODE })
+		])
+
+		const statuses = [first.status, second.status].sort()
+
+		expect(statuses).toEqual([200, 401])
+	})
+
 	test('missing fields return a distinct 400, not the generic-failure body', async() => {
 		const response = await request(app).post('/auth/verify-code').send({ email: EMAIL })
 


### PR DESCRIPTION
…fail-closed SESSION_SECRET in production

## What

<!-- Summary of the change -->

## Data Minimization & Leak Prevention gate

Required for every PR touching an API response, logging, or error handling
(see `docs/plan/criticseven-modernization-plan.md`, Standing Requirement):

- [ ] Every API response goes through an explicit-allowlist DTO in `server/serializers/` — no raw model documents or upstream payloads sent to the client, no select-minus/denylist shaping
- [ ] No email, password/auth-code hashes, raw `HonestyLog` entries, or internal `_id` (where a public id suffices) in any response
- [ ] Error responses: generic message + error code only in production; full detail stays in server logs (central `errorHandler`, no per-route `res.status(500).send(error.message)`)
- [ ] No `console.log`/`console.error` of request bodies, user objects, auth codes, or raw upstream errors (axios errors embed the TMDB `api_key`)
- [ ] Request logging (morgan) does not log bodies; `/auth/*` URLs are logged without query strings

Auth routes only (Phase 3+):

- [ ] `POST /auth/verify-code` response never echoes the submitted or stored code
- [ ] `POST /auth/request-code` returns the identical response whether or not the email exists (no account enumeration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Production deployments now fail safely when a session secret is not configured.
  * Verification codes are enforced as single-use, including when multiple verification attempts happen simultaneously.

* **Bug Fixes**
  * Prevented concurrent requests from successfully reusing the same verification code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->