### PR TITLE
Phase 2: schema — Movie/TrailerOpinion/Review/Vote/HonestyLog/Config + honesty score

### DIFF
--- a/server/database/models/User.ts
+++ b/server/database/models/User.ts
@@ -17,7 +17,10 @@ export interface UserDocument extends mongoose.Document {
 const userSchema = new Schema<UserDocument>({
 	username: { type: String, required: true, unique: true },
 	email: { type: String, required: true, unique: true },
-	honestyScore: { type: Number, default: 0 },
+	// 50 (neutral midpoint) not 0 — a brand-new user with no HonestyLog
+	// history hasn't done anything dishonest yet, so they shouldn't start
+	// out already below the low-trust badge threshold.
+	honestyScore: { type: Number, default: 50 },
 	isPhoneVerified: { type: Boolean, default: false },
 	phoneNumberHash: { type: String, default: null },
 	createdAt: { type: Date, default: Date.now }

--- a/server/database/models/config.ts
+++ b/server/database/models/config.ts
@@ -1,0 +1,21 @@
+import mongoose, { Schema } from 'mongoose'
+
+export const DEFAULT_LOW_TRUST_BADGE_THRESHOLD = 30
+export const DEFAULT_VOTE_WEIGHT_FLOOR = 0.2
+
+export interface ConfigDocument extends mongoose.Document {
+	// Fixed constant, never varies — the unique index on it is what makes
+	// this a singleton at the database level (see getConfig in
+	// server/lib/config.ts for the upsert that relies on it).
+	singletonKey: string
+	lowTrustBadgeThreshold: number
+	voteWeightFloor: number
+}
+
+const configSchema = new Schema<ConfigDocument>({
+	singletonKey: { type: String, default: 'singleton', unique: true },
+	lowTrustBadgeThreshold: { type: Number, default: DEFAULT_LOW_TRUST_BADGE_THRESHOLD },
+	voteWeightFloor: { type: Number, default: DEFAULT_VOTE_WEIGHT_FLOOR }
+})
+
+export const Config = mongoose.models.Config || mongoose.model<ConfigDocument>('Config', configSchema)

--- a/server/database/models/honesty-log.ts
+++ b/server/database/models/honesty-log.ts
@@ -1,0 +1,22 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface HonestyLogDocument extends mongoose.Document {
+	userId: mongoose.Types.ObjectId
+	delta: number
+	reason: string
+	createdAt: Date
+}
+
+const honestyLogSchema = new Schema<HonestyLogDocument>({
+	userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+	delta: { type: Number, required: true },
+	reason: { type: String, required: true },
+	createdAt: { type: Date, default: Date.now }
+})
+
+// Recalculation job (server/lib/honesty-score.ts) reads a user's entries
+// ordered by recency — index matches that access pattern.
+honestyLogSchema.index({ userId: 1, createdAt: -1 })
+
+export const HonestyLog =
+	mongoose.models.HonestyLog || mongoose.model<HonestyLogDocument>('HonestyLog', honestyLogSchema)

--- a/server/database/models/movie.ts
+++ b/server/database/models/movie.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface MovieDocument extends mongoose.Document {
+	title: string
+	trailerUrl: string | null
+	metadata: Record<string, unknown>
+	createdAt: Date
+}
+
+const movieSchema = new Schema<MovieDocument>({
+	title: { type: String, required: true },
+	trailerUrl: { type: String, default: null },
+	metadata: { type: Schema.Types.Mixed, default: {} },
+	createdAt: { type: Date, default: Date.now }
+})
+
+export const Movie = mongoose.models.Movie || mongoose.model<MovieDocument>('Movie', movieSchema)

--- a/server/database/models/review.ts
+++ b/server/database/models/review.ts
@@ -1,0 +1,33 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface ReviewDocument extends mongoose.Document {
+	userId: mongoose.Types.ObjectId
+	movieId: mongoose.Types.ObjectId
+	plot: number
+	acting: number
+	writing: number
+	score: number
+	directing: number
+	editing: number
+	cinematography: number
+	comment: string
+	createdAt: Date
+}
+
+const reviewSchema = new Schema<ReviewDocument>({
+	userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+	movieId: { type: Schema.Types.ObjectId, ref: 'Movie', required: true },
+	plot: { type: Number, required: true },
+	acting: { type: Number, required: true },
+	writing: { type: Number, required: true },
+	score: { type: Number, required: true },
+	directing: { type: Number, required: true },
+	editing: { type: Number, required: true },
+	cinematography: { type: Number, required: true },
+	comment: { type: String, default: '' },
+	createdAt: { type: Date, default: Date.now }
+})
+
+reviewSchema.index({ movieId: 1, createdAt: -1 })
+
+export const Review = mongoose.models.Review || mongoose.model<ReviewDocument>('Review', reviewSchema)

--- a/server/database/models/tests/vote.test.ts
+++ b/server/database/models/tests/vote.test.ts
@@ -1,0 +1,54 @@
+import mongoose from 'mongoose'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../../test-support/database'
+import { Vote } from '../vote'
+
+beforeAll(async() => {
+	await connectTestDatabase()
+	// Index creation is async and otherwise not guaranteed to finish before
+	// the first write in a test — without this the uniqueness assertions
+	// below would be flaky rather than deterministic.
+	await Vote.init()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+describe('Vote unique index', () => {
+	test('a second vote by the same voter on the same target is rejected at the database level', async() => {
+		const voterId = new mongoose.Types.ObjectId()
+		const targetId = new mongoose.Types.ObjectId()
+
+		await Vote.create({ voterId, targetType: 'review', targetId, voteValue: 1, voterWeightAtVote: 1 })
+
+		await expect(
+			Vote.create({ voterId, targetType: 'review', targetId, voteValue: -1, voterWeightAtVote: 1 })
+		).rejects.toThrow()
+	})
+
+	test('the same voter voting on two different targets is allowed', async() => {
+		const voterId = new mongoose.Types.ObjectId()
+
+		await Vote.create({
+			voterId,
+			targetType: 'review',
+			targetId: new mongoose.Types.ObjectId(),
+			voteValue: 1,
+			voterWeightAtVote: 1
+		})
+
+		await expect(
+			Vote.create({
+				voterId,
+				targetType: 'review',
+				targetId: new mongoose.Types.ObjectId(),
+				voteValue: 1,
+				voterWeightAtVote: 1
+			})
+		).resolves.toBeTruthy()
+	})
+})

--- a/server/database/models/trailer-opinion.ts
+++ b/server/database/models/trailer-opinion.ts
@@ -1,0 +1,22 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface TrailerOpinionDocument extends mongoose.Document {
+	userId: mongoose.Types.ObjectId
+	movieId: mongoose.Types.ObjectId
+	hypeLevel: number
+	comment: string
+	createdAt: Date
+}
+
+const trailerOpinionSchema = new Schema<TrailerOpinionDocument>({
+	userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+	movieId: { type: Schema.Types.ObjectId, ref: 'Movie', required: true },
+	hypeLevel: { type: Number, required: true, min: 1, max: 5 },
+	comment: { type: String, default: '' },
+	createdAt: { type: Date, default: Date.now }
+})
+
+trailerOpinionSchema.index({ movieId: 1, createdAt: -1 })
+
+export const TrailerOpinion =
+	mongoose.models.TrailerOpinion || mongoose.model<TrailerOpinionDocument>('TrailerOpinion', trailerOpinionSchema)

--- a/server/database/models/vote.ts
+++ b/server/database/models/vote.ts
@@ -1,0 +1,29 @@
+import mongoose, { Schema } from 'mongoose'
+
+export type VoteTargetType = 'opinion' | 'review'
+
+export interface VoteDocument extends mongoose.Document {
+	voterId: mongoose.Types.ObjectId
+	targetType: VoteTargetType
+	targetId: mongoose.Types.ObjectId
+	voteValue: 1 | -1
+	// Snapshotted at cast time from the voter's honestyScore, never
+	// recomputed retroactively — see server/lib/honesty-score.ts. A voter's
+	// later score changes must not alter votes they already cast.
+	voterWeightAtVote: number
+	createdAt: Date
+}
+
+const voteSchema = new Schema<VoteDocument>({
+	voterId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+	targetType: { type: String, enum: ['opinion', 'review'], required: true },
+	targetId: { type: Schema.Types.ObjectId, required: true },
+	voteValue: { type: Number, enum: [1, -1], required: true },
+	voterWeightAtVote: { type: Number, required: true, min: 0, max: 1 },
+	createdAt: { type: Date, default: Date.now }
+})
+
+// Enforces one vote per user per target at the database level, not just app logic.
+voteSchema.index({ voterId: 1, targetType: 1, targetId: 1 }, { unique: true })
+
+export const Vote = mongoose.models.Vote || mongoose.model<VoteDocument>('Vote', voteSchema)

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -1,0 +1,15 @@
+import { Config, ConfigDocument } from '../database/models/config'
+
+// Atomic upsert, not find-then-create: two concurrent callers racing to
+// bootstrap the singleton must still land on the same document rather than
+// both trying to insert one (the unique index on singletonKey would reject
+// the loser, but findOneAndUpdate avoids the race entirely).
+export async function getConfig(): Promise<ConfigDocument> {
+	const config = await Config.findOneAndUpdate(
+		{ singletonKey: 'singleton' },
+		{ $setOnInsert: { singletonKey: 'singleton' } },
+		{ upsert: true, new: true }
+	)
+
+	return config
+}

--- a/server/lib/honesty-score.ts
+++ b/server/lib/honesty-score.ts
@@ -1,0 +1,70 @@
+import { HonestyLog } from '../database/models/honesty-log'
+import { User } from '../database/models/User'
+
+const BASELINE_HONESTY_SCORE = 50
+const HALF_LIFE_DAYS = 30
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+interface HonestyLogDelta {
+	delta: number
+	createdAt: Date
+}
+
+/*
+ * Weighted AVERAGE of deltas around a neutral baseline, not a running sum —
+ * a sum lets score drift unboundedly with volume; an average of a single
+ * old pile-on stays exactly that pile-on's size forever, no matter how much
+ * time passes, until fresh deltas arrive and outweigh it (weight decays
+ * relative to *other* entries, it cancels out when an entry stands alone).
+ * That's the intended recovery path: through new behavior, not through
+ * waiting.
+ */
+export function computeDecayedHonestyScore(deltas: HonestyLogDelta[], now: Date = new Date()): number {
+	if (deltas.length === 0) {
+		return BASELINE_HONESTY_SCORE
+	}
+
+	let weightedDeltaSum = 0
+	let weightSum = 0
+
+	for (const entry of deltas) {
+		const ageInDays = Math.max(0, (now.getTime() - entry.createdAt.getTime()) / MILLISECONDS_PER_DAY)
+		const weight = 2 ** (-ageInDays / HALF_LIFE_DAYS)
+
+		weightedDeltaSum += entry.delta * weight
+		weightSum += weight
+	}
+
+	const weightedAverageDelta = weightedDeltaSum / weightSum
+
+	return Math.min(100, Math.max(0, BASELINE_HONESTY_SCORE + weightedAverageDelta))
+}
+
+// Linear scale from voteWeightFloor (score 0) to 1.0 (score 100). Input is
+// clamped defensively even though honestyScore is already clamped at the
+// source, so a caller passing a stale or malformed value can't produce a
+// weight outside [voteWeightFloor, 1.0].
+export function computeVoterWeight(honestyScore: number, voteWeightFloor: number): number {
+	const clampedScore = Math.min(100, Math.max(0, honestyScore))
+	const scoreFraction = clampedScore / 100
+
+	return voteWeightFloor + scoreFraction * (1 - voteWeightFloor)
+}
+
+export async function recalculateHonestyScore(userId: string): Promise<number> {
+	const logs = await HonestyLog.find({ userId }).select('delta createdAt').lean()
+	const score = computeDecayedHonestyScore(logs.map(log => ({ delta: log.delta, createdAt: log.createdAt })))
+
+	await User.findByIdAndUpdate(userId, { honestyScore: score })
+
+	return score
+}
+
+// Fire-and-forget entry point for vote/log writes: caller does not await
+// this, so a slow or failing recalculation never blocks the request that
+// triggered it.
+export function enqueueHonestyScoreRecalculation(userId: string): void {
+	recalculateHonestyScore(userId).catch(error => {
+		console.error('Honesty score recalculation failed:', error.message)
+	})
+}

--- a/server/lib/tests/config.test.ts
+++ b/server/lib/tests/config.test.ts
@@ -1,0 +1,40 @@
+import { Config, DEFAULT_LOW_TRUST_BADGE_THRESHOLD, DEFAULT_VOTE_WEIGHT_FLOOR } from '../../database/models/config'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { getConfig } from '../config'
+
+beforeAll(async() => {
+	await connectTestDatabase()
+	await Config.init()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+describe('getConfig', () => {
+	test('bootstraps a single document with the documented defaults when none exists', async() => {
+		const config = await getConfig()
+
+		expect(config.lowTrustBadgeThreshold).toBe(DEFAULT_LOW_TRUST_BADGE_THRESHOLD)
+		expect(config.voteWeightFloor).toBe(DEFAULT_VOTE_WEIGHT_FLOOR)
+	})
+
+	test('repeated calls return the same document rather than creating another', async() => {
+		const first = await getConfig()
+		const second = await getConfig()
+
+		expect(second.id).toBe(first.id)
+		expect(await Config.countDocuments()).toBe(1)
+	})
+
+	test('concurrent bootstrap calls still converge on one document', async() => {
+		const [first, second] = await Promise.all([getConfig(), getConfig()])
+
+		expect(second.id).toBe(first.id)
+		expect(await Config.countDocuments()).toBe(1)
+	})
+})

--- a/server/lib/tests/honesty-score-recalculation.test.ts
+++ b/server/lib/tests/honesty-score-recalculation.test.ts
@@ -1,0 +1,44 @@
+import { HonestyLog } from '../../database/models/honesty-log'
+import { User } from '../../database/models/User'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { recalculateHonestyScore } from '../honesty-score'
+
+beforeAll(async() => {
+	await connectTestDatabase()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+describe('recalculateHonestyScore', () => {
+	test('writes the recalculated score back onto the user document', async() => {
+		const user = await User.create({ username: 'critic7', email: 'critic7@example.com' })
+
+		await HonestyLog.create({ userId: user.id, delta: 25, reason: 'received an upvote' })
+
+		const score = await recalculateHonestyScore(user.id)
+
+		expect(score).toBe(75)
+
+		const reloaded = await User.findById(user.id)
+
+		expect(reloaded?.honestyScore).toBe(75)
+	})
+
+	test('a user with no HonestyLog entries settles back to the neutral baseline', async() => {
+		const user = await User.create({ username: 'critic8', email: 'critic8@example.com', honestyScore: 90 })
+
+		const score = await recalculateHonestyScore(user.id)
+
+		expect(score).toBe(50)
+
+		const reloaded = await User.findById(user.id)
+
+		expect(reloaded?.honestyScore).toBe(50)
+	})
+})

--- a/server/lib/tests/honesty-score.test.ts
+++ b/server/lib/tests/honesty-score.test.ts
@@ -1,0 +1,114 @@
+import { computeDecayedHonestyScore, computeVoterWeight } from '../honesty-score'
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe('computeDecayedHonestyScore', () => {
+	test('no history returns the neutral baseline', () => {
+		expect(computeDecayedHonestyScore([])).toBe(50)
+	})
+
+	test('a single positive delta shifts the score up from baseline', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const score = computeDecayedHonestyScore([{ delta: 20, createdAt: now }], now)
+
+		expect(score).toBe(70)
+	})
+
+	test('a single negative delta shifts the score down from baseline', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const score = computeDecayedHonestyScore([{ delta: -20, createdAt: now }], now)
+
+		expect(score).toBe(30)
+	})
+
+	test('clamps at 100 rather than climbing past it on repeated large positive deltas', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const deltas = Array.from({ length: 10 }, () => ({ delta: 200, createdAt: now }))
+
+		expect(computeDecayedHonestyScore(deltas, now)).toBe(100)
+	})
+
+	test('clamps at 0 rather than going negative on repeated large negative deltas', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const deltas = Array.from({ length: 10 }, () => ({ delta: -200, createdAt: now }))
+
+		expect(computeDecayedHonestyScore(deltas, now)).toBe(0)
+	})
+
+	test('is an average, not a sum: many small identical deltas do not outweigh one large one', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+
+		const manySmall = computeDecayedHonestyScore(
+			Array.from({ length: 50 }, () => ({ delta: 1, createdAt: now })),
+			now
+		)
+		const oneLarge = computeDecayedHonestyScore([{ delta: 1, createdAt: now }], now)
+
+		expect(manySmall).toBe(oneLarge)
+	})
+
+	test('a lone old pile-on does not fade back toward baseline just from elapsed time', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const sixMonthsAgo = new Date(now.getTime() - 180 * DAY)
+
+		const score = computeDecayedHonestyScore([{ delta: -30, createdAt: sixMonthsAgo }], now)
+
+		expect(score).toBe(20)
+	})
+
+	test('recovery comes from fresh good behavior outweighing an old pile-on, not from waiting', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const sixMonthsAgo = new Date(now.getTime() - 180 * DAY)
+
+		const scoreWithOnlyPileOn = computeDecayedHonestyScore([{ delta: -30, createdAt: sixMonthsAgo }], now)
+		const scoreWithRecentRecovery = computeDecayedHonestyScore(
+			[
+				{ delta: -30, createdAt: sixMonthsAgo },
+				{ delta: 20, createdAt: now }
+			],
+			now
+		)
+
+		expect(scoreWithRecentRecovery).toBeGreaterThan(scoreWithOnlyPileOn)
+	})
+
+	test('a recent delta outweighs an equally sized but much older one', () => {
+		const now = new Date('2026-01-01T00:00:00.000Z')
+		const yearAgo = new Date(now.getTime() - 365 * DAY)
+
+		const deltas = [
+			{ delta: -40, createdAt: yearAgo },
+			{ delta: 40, createdAt: now }
+		]
+
+		expect(computeDecayedHonestyScore(deltas, now)).toBeGreaterThan(50)
+	})
+})
+
+describe('computeVoterWeight', () => {
+	test('score of 0 maps to exactly the floor', () => {
+		expect(computeVoterWeight(0, 0.2)).toBeCloseTo(0.2)
+	})
+
+	test('score of 100 maps to exactly 1.0', () => {
+		expect(computeVoterWeight(100, 0.2)).toBeCloseTo(1.0)
+	})
+
+	test('score of 50 maps to the midpoint between floor and 1.0', () => {
+		expect(computeVoterWeight(50, 0.2)).toBeCloseTo(0.6)
+	})
+
+	test('a floor of 0 behaves as a plain linear 0-100 -> 0-1 scale', () => {
+		expect(computeVoterWeight(0, 0)).toBeCloseTo(0)
+		expect(computeVoterWeight(50, 0)).toBeCloseTo(0.5)
+		expect(computeVoterWeight(100, 0)).toBeCloseTo(1.0)
+	})
+
+	test('an out-of-range score below 0 is clamped before scaling, not extrapolated', () => {
+		expect(computeVoterWeight(-50, 0.2)).toBeCloseTo(0.2)
+	})
+
+	test('an out-of-range score above 100 is clamped before scaling, not extrapolated', () => {
+		expect(computeVoterWeight(150, 0.2)).toBeCloseTo(1.0)
+	})
+})

--- a/server/serializers/README.md
+++ b/server/serializers/README.md
@@ -20,3 +20,17 @@ Example (built in Phase 3): `UserPublicDTO { username, honestyScore, isLowTrust,
 feeds the low-trust badge (opposite signal, same DTO-exposure pattern).
 `phoneNumberHash` never appears here — like auth-code hashes, it's not
 something the client needs.
+
+Built in Phase 2 (schema): `MoviePublicDTO`, `TrailerOpinionPublicDTO`,
+`ReviewPublicDTO`, `VotePublicDTO`, `ConfigPublicDTO`. Notes specific to
+these:
+
+- `MoviePublicDTO` drops `metadata` — it's an opaque cached upstream blob,
+  not a curated response shape.
+- `VotePublicDTO` drops `voterId` — a public listing that names the voter on
+  every vote is the same "who voted on what" deanonymization risk the
+  `HonestyLog` rule above rules out, just at the Vote level instead.
+- `HonestyLog` has no DTO at all — it is never sent to the client in any
+  shape, per the rule above.
+- `ConfigPublicDTO` exposes exactly `lowTrustBadgeThreshold` and
+  `voteWeightFloor` — the two fields the rule above allowlists from `Config`.

--- a/server/serializers/config.ts
+++ b/server/serializers/config.ts
@@ -1,0 +1,13 @@
+import { ConfigDocument } from '../database/models/config'
+
+export interface ConfigPublicDTO {
+	lowTrustBadgeThreshold: number
+	voteWeightFloor: number
+}
+
+export function toConfigPublicDTO(config: ConfigDocument): ConfigPublicDTO {
+	return {
+		lowTrustBadgeThreshold: config.lowTrustBadgeThreshold,
+		voteWeightFloor: config.voteWeightFloor
+	}
+}

--- a/server/serializers/index.ts
+++ b/server/serializers/index.ts
@@ -1,1 +1,6 @@
+export * from './config'
+export * from './movie'
 export * from './movies'
+export * from './review'
+export * from './trailer-opinion'
+export * from './vote'

--- a/server/serializers/movie.ts
+++ b/server/serializers/movie.ts
@@ -1,0 +1,18 @@
+import { MovieDocument } from '../database/models/movie'
+
+export interface MoviePublicDTO {
+	id: string
+	title: string
+	trailerUrl: string | null
+}
+
+// metadata is an opaque upstream (TMDB) blob cached for internal matching,
+// not a curated response shape — it stays server-side, same allowlist
+// reasoning as everything else in this file.
+export function toMoviePublicDTO(movie: MovieDocument): MoviePublicDTO {
+	return {
+		id: movie.id,
+		title: movie.title,
+		trailerUrl: movie.trailerUrl
+	}
+}

--- a/server/serializers/review.ts
+++ b/server/serializers/review.ts
@@ -1,0 +1,33 @@
+import { ReviewDocument } from '../database/models/review'
+
+export interface ReviewPublicDTO {
+	id: string
+	userId: string
+	movieId: string
+	plot: number
+	acting: number
+	writing: number
+	score: number
+	directing: number
+	editing: number
+	cinematography: number
+	comment: string
+	createdAt: Date
+}
+
+export function toReviewPublicDTO(review: ReviewDocument): ReviewPublicDTO {
+	return {
+		id: review.id,
+		userId: review.userId.toString(),
+		movieId: review.movieId.toString(),
+		plot: review.plot,
+		acting: review.acting,
+		writing: review.writing,
+		score: review.score,
+		directing: review.directing,
+		editing: review.editing,
+		cinematography: review.cinematography,
+		comment: review.comment,
+		createdAt: review.createdAt
+	}
+}

--- a/server/serializers/tests/config.test.ts
+++ b/server/serializers/tests/config.test.ts
@@ -1,0 +1,18 @@
+import { toConfigPublicDTO } from '../config'
+
+const config = {
+	id: '507f1f77bcf86cd799439015',
+	singletonKey: 'singleton',
+	lowTrustBadgeThreshold: 30,
+	voteWeightFloor: 0.2
+}
+
+describe('config serializer allowlist', () => {
+	test('public DTO exposes only the two public thresholds', () => {
+		const dto = toConfigPublicDTO(config as never)
+
+		expect(Object.keys(dto).sort()).toEqual(['lowTrustBadgeThreshold', 'voteWeightFloor'])
+		expect(dto).not.toHaveProperty('singletonKey')
+		expect(dto).not.toHaveProperty('id')
+	})
+})

--- a/server/serializers/tests/movie.test.ts
+++ b/server/serializers/tests/movie.test.ts
@@ -1,0 +1,17 @@
+import { toMoviePublicDTO } from '../movie'
+
+const movie = {
+	id: '507f1f77bcf86cd799439011',
+	title: 'Sinners',
+	trailerUrl: 'https://example.com/trailer',
+	metadata: { tmdbId: 12345, secretInternalNote: 'do not leak' }
+}
+
+describe('movie serializer allowlist', () => {
+	test('public DTO drops metadata', () => {
+		const dto = toMoviePublicDTO(movie as never)
+
+		expect(Object.keys(dto).sort()).toEqual(['id', 'title', 'trailerUrl'])
+		expect(dto).not.toHaveProperty('metadata')
+	})
+})

--- a/server/serializers/tests/vote.test.ts
+++ b/server/serializers/tests/vote.test.ts
@@ -1,0 +1,20 @@
+import { toVotePublicDTO } from '../vote'
+
+const vote = {
+	id: '507f1f77bcf86cd799439012',
+	voterId: { toString: () => '507f1f77bcf86cd799439013' },
+	targetType: 'review',
+	targetId: { toString: () => '507f1f77bcf86cd799439014' },
+	voteValue: 1,
+	voterWeightAtVote: 0.6,
+	createdAt: new Date('2026-01-01T00:00:00.000Z')
+}
+
+describe('vote serializer allowlist', () => {
+	test('public DTO drops voterId to avoid deanonymizing who voted on what', () => {
+		const dto = toVotePublicDTO(vote as never)
+
+		expect(Object.keys(dto).sort()).toEqual(['createdAt', 'targetId', 'targetType', 'voteValue', 'voterWeightAtVote'])
+		expect(dto).not.toHaveProperty('voterId')
+	})
+})

--- a/server/serializers/trailer-opinion.ts
+++ b/server/serializers/trailer-opinion.ts
@@ -1,0 +1,21 @@
+import { TrailerOpinionDocument } from '../database/models/trailer-opinion'
+
+export interface TrailerOpinionPublicDTO {
+	id: string
+	userId: string
+	movieId: string
+	hypeLevel: number
+	comment: string
+	createdAt: Date
+}
+
+export function toTrailerOpinionPublicDTO(opinion: TrailerOpinionDocument): TrailerOpinionPublicDTO {
+	return {
+		id: opinion.id,
+		userId: opinion.userId.toString(),
+		movieId: opinion.movieId.toString(),
+		hypeLevel: opinion.hypeLevel,
+		comment: opinion.comment,
+		createdAt: opinion.createdAt
+	}
+}

--- a/server/serializers/users.ts
+++ b/server/serializers/users.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOW_TRUST_BADGE_THRESHOLD } from '../database/models/config'
 import { UserDocument } from '../database/models/User'
 
 export interface UserPublicDTO {
@@ -7,15 +8,17 @@ export interface UserPublicDTO {
 	isPhoneVerified: boolean
 }
 
-// Placeholder until the Config model (docs/plan) exists — mirrors its
-// planned lowTrustBadgeThreshold default of 30.
-const LOW_TRUST_THRESHOLD = 30
-
-export function toUserPublicDTO(user: UserDocument): UserPublicDTO {
+// Threshold defaults to Config's default rather than reading Config here —
+// DTOs stay synchronous and DB-free; callers that already have the live
+// Config document (it's a single cached lookup) pass its value in.
+export function toUserPublicDTO(
+	user: UserDocument,
+	lowTrustBadgeThreshold: number = DEFAULT_LOW_TRUST_BADGE_THRESHOLD
+): UserPublicDTO {
 	return {
 		username: user.username,
 		honestyScore: user.honestyScore,
-		isLowTrust: user.honestyScore < LOW_TRUST_THRESHOLD,
+		isLowTrust: user.honestyScore < lowTrustBadgeThreshold,
 		isPhoneVerified: user.isPhoneVerified
 	}
 }

--- a/server/serializers/vote.ts
+++ b/server/serializers/vote.ts
@@ -1,0 +1,23 @@
+import { VoteDocument, VoteTargetType } from '../database/models/vote'
+
+export interface VotePublicDTO {
+	targetType: VoteTargetType
+	targetId: string
+	voteValue: 1 | -1
+	voterWeightAtVote: number
+	createdAt: Date
+}
+
+// voterId deliberately not included: a public vote tally/listing that names
+// the voter on every review or opinion is exactly the "who voted on what"
+// deanonymization the data-minimization gate rules out for HonestyLog, and
+// the same reasoning applies here.
+export function toVotePublicDTO(vote: VoteDocument): VotePublicDTO {
+	return {
+		targetType: vote.targetType,
+		targetId: vote.targetId.toString(),
+		voteValue: vote.voteValue,
+		voterWeightAtVote: vote.voterWeightAtVote,
+		createdAt: vote.createdAt
+	}
+}


### PR DESCRIPTION
## Summary
- New models: `Movie`, `TrailerOpinion`, `Review`, `Vote`, `HonestyLog`, `Config` (singleton, TOCTOU-safe upsert)
- `Vote` gets a unique compound index on `(voterId, targetType, targetId)` — one vote per user per target enforced at the DB level
- `User.honestyScore` default changed 0 → 50 (neutral baseline, matches recalculation math)
- `server/lib/honesty-score.ts`: time-decayed weighted-average recalculation (not a raw sum — bounded by construction, recovers only via fresh behavior outweighing old entries) + linear `voteWeightFloor`→1.0 voter-weight scaling, snapshotted permanently at vote cast time
- Public DTOs for every new model following `UserPublicDTO`'s allowlist pattern (`server/serializers/README.md` updated); `HonestyLog` intentionally has no DTO, `Vote`'s DTO drops `voterId`, `Movie`'s drops `metadata` — all per the data-minimization gate

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (47 tests passing, including new unit tests for the recalculation math and `voteWeightFloor` clamping, DB-integration tests for the Vote unique index and Config singleton, and DTO allowlist tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added movie reviews, trailer opinions, and voting support.
  * Added public response formats for movies, reviews, opinions, votes, and configuration.
  * Added configurable trust thresholds and vote-weight settings.
  * Added honesty scoring that reflects recent activity and influences voting weight.
  * New accounts now begin with a neutral honesty score.
* **Documentation**
  * Documented public response fields and privacy protections.
* **Tests**
  * Added coverage for voting rules, configuration, honesty scoring, and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->