### PR TITLE
Phase 4: Cloudflare Images service — poster/backdrop proxy + cache

### DIFF
--- a/server/actions/movies.ts
+++ b/server/actions/movies.ts
@@ -10,7 +10,7 @@ export const getPopular = async(request: Request, response: Response, next: Next
 	try {
 		const popularMovies = await Tmdb.getPopularMovies()
 
-		response.send(toMovieListDTO(popularMovies))
+		response.send(await toMovieListDTO(popularMovies))
 	} catch (error) {
 		next(error)
 	}
@@ -20,7 +20,7 @@ export const getLatest = async(request: Request, response: Response, next: NextF
 	try {
 		const latestMovie = await Tmdb.getLatestMovies()
 
-		response.send(toMovieDetailsDTO(latestMovie))
+		response.send(await toMovieDetailsDTO(latestMovie))
 	} catch (error) {
 		next(error)
 	}
@@ -30,7 +30,7 @@ export const getUpcoming = async(request: Request, response: Response, next: Nex
 	try {
 		const upcomingMovies = await Tmdb.getUpcomingMovies()
 
-		response.send(toMovieListDTO(upcomingMovies))
+		response.send(await toMovieListDTO(upcomingMovies))
 	} catch (error) {
 		next(error)
 	}
@@ -40,7 +40,7 @@ export const getDetails = async(request: Request, response: Response, next: Next
 	try {
 		const movieDetails = await Tmdb.getMovieDetails(String(request.query.movieId))
 
-		response.send(toMovieDetailsDTO(movieDetails))
+		response.send(await toMovieDetailsDTO(movieDetails))
 	} catch (error) {
 		next(error)
 	}
@@ -60,7 +60,7 @@ export const getNowPlaying = async(request: Request, response: Response, next: N
 	try {
 		const nowPlaying = await Tmdb.getPlayingMovies()
 
-		response.send(toMovieListDTO(nowPlaying))
+		response.send(await toMovieListDTO(nowPlaying))
 	} catch (error) {
 		next(error)
 	}

--- a/server/database/models/image-cache.ts
+++ b/server/database/models/image-cache.ts
@@ -1,0 +1,16 @@
+import mongoose, { Schema } from 'mongoose'
+
+export interface ImageCacheDocument extends mongoose.Document {
+	tmdbImagePath: string
+	cloudflareImageUrl: string
+	createdAt: Date
+}
+
+const imageCacheSchema = new Schema<ImageCacheDocument>({
+	tmdbImagePath: { type: String, required: true, unique: true },
+	cloudflareImageUrl: { type: String, required: true },
+	createdAt: { type: Date, default: Date.now }
+})
+
+export const ImageCache =
+	mongoose.models.ImageCache || mongoose.model<ImageCacheDocument>('ImageCache', imageCacheSchema)

--- a/server/lib/image-service.ts
+++ b/server/lib/image-service.ts
@@ -1,0 +1,97 @@
+import mongoose from 'mongoose'
+import { ImageCache } from '../database/models/image-cache'
+
+const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/original'
+
+function buildTmdbDirectUrl(tmdbImagePath: string): string {
+	return `${TMDB_IMAGE_BASE_URL}${tmdbImagePath}`
+}
+
+// The Cloudflare API token travels only in a request header, never
+// interpolated into a URL or error string (unlike the TMDB api_key, which is
+// a query param and needed the redaction fix in the error handler) — so
+// there is nothing here for a thrown error or log line to leak.
+async function uploadImageFromUrl(accountId: string, apiToken: string, sourceUrl: string): Promise<string | null> {
+	const body = new FormData()
+
+	body.set('url', sourceUrl)
+
+	const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/images/v1`, {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${apiToken}` },
+		body
+	})
+
+	if (!response.ok) {
+		return null
+	}
+
+	const payload = (await response.json()) as { success: boolean; result?: { variants?: string[] } }
+
+	if (!payload.success) {
+		return null
+	}
+
+	return payload.result?.variants?.[0] ?? null
+}
+
+/*
+ * Thin swappable-provider abstraction (docs/plan Phase 4): callers ask for a
+ * poster/backdrop URL and get one back, never touching Cloudflare or TMDB
+ * directly. Every early-exit below falls back to the raw TMDB CDN URL rather
+ * than throwing, so a missing config, a down Cloudflare API, or a
+ * disconnected database degrades to "works like before this PR" instead of
+ * a broken image or a 500.
+ */
+export async function getPosterUrl(tmdbImagePath: string | null): Promise<string | null> {
+	if (!tmdbImagePath) {
+		return null
+	}
+
+	const directUrl = buildTmdbDirectUrl(tmdbImagePath)
+
+	if (mongoose.connection.readyState !== 1) {
+		return directUrl
+	}
+
+	const cached = await ImageCache.findOne({ tmdbImagePath })
+
+	if (cached) {
+		return cached.cloudflareImageUrl
+	}
+
+	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+	const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN
+
+	if (!accountId || !apiToken) {
+		return directUrl
+	}
+
+	try {
+		const cloudflareImageUrl = await uploadImageFromUrl(accountId, apiToken, directUrl)
+
+		if (!cloudflareImageUrl) {
+			return directUrl
+		}
+
+		// $setOnInsert, not a plain upsert-with-new-value: two concurrent
+		// misses for the same path can both reach here and both upload, but
+		// only the first write should win the cache row, so every later
+		// reader converges on the same URL rather than flip-flopping.
+		const cacheEntry = await ImageCache.findOneAndUpdate(
+			{ tmdbImagePath },
+			{ $setOnInsert: { tmdbImagePath, cloudflareImageUrl } },
+			{ upsert: true, new: true }
+		)
+
+		return cacheEntry.cloudflareImageUrl
+	} catch (error) {
+		console.error('Cloudflare Images upload failed, falling back to TMDB URL:', (error as Error).message)
+		return directUrl
+	}
+}
+
+// Posters and backdrops are both just images to Cloudflare — same upload,
+// same cache, same fallback. Kept as a named alias so call sites read
+// clearly rather than because the mechanics differ.
+export const getBackdropUrl = getPosterUrl

--- a/server/lib/tests/image-service.test.ts
+++ b/server/lib/tests/image-service.test.ts
@@ -1,0 +1,114 @@
+import { ImageCache } from '../../database/models/image-cache'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { getPosterUrl } from '../image-service'
+
+const TMDB_DIRECT_URL = 'https://image.tmdb.org/t/p/original/poster.jpg'
+const CLOUDFLARE_URL = 'https://imagedelivery.net/account-hash/image-id/public'
+
+function mockCloudflareUpload(overrides: Partial<{ ok: boolean; success: boolean; variants: string[] }> = {}) {
+	const ok = overrides.ok ?? true
+	const success = overrides.success ?? true
+	const variants = overrides.variants ?? [CLOUDFLARE_URL]
+
+	return jest.spyOn(global, 'fetch').mockResolvedValue({
+		ok,
+		json: async() => ({ success, result: { variants } })
+	} as Response)
+}
+
+beforeAll(async() => {
+	await connectTestDatabase()
+	await ImageCache.init()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+	jest.restoreAllMocks()
+	delete process.env.CLOUDFLARE_ACCOUNT_ID
+	delete process.env.CLOUDFLARE_IMAGES_API_TOKEN
+})
+
+describe('getPosterUrl', () => {
+	test('null path returns null without any network call', async() => {
+		const fetchSpy = jest.spyOn(global, 'fetch')
+
+		expect(await getPosterUrl(null)).toBeNull()
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	test('not configured (no Cloudflare credentials) falls back to the direct TMDB URL', async() => {
+		const fetchSpy = jest.spyOn(global, 'fetch')
+
+		const url = await getPosterUrl('/poster.jpg')
+
+		expect(url).toBe(TMDB_DIRECT_URL)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	test('cache miss: uploads through Cloudflare and persists the mapping', async() => {
+		process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id'
+		process.env.CLOUDFLARE_IMAGES_API_TOKEN = 'super-secret-token'
+		const fetchSpy = mockCloudflareUpload()
+
+		const url = await getPosterUrl('/poster.jpg')
+
+		expect(url).toBe(CLOUDFLARE_URL)
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+		const cached = await ImageCache.findOne({ tmdbImagePath: '/poster.jpg' })
+
+		expect(cached?.cloudflareImageUrl).toBe(CLOUDFLARE_URL)
+	})
+
+	test('cache hit: a second call for the same path does not re-upload', async() => {
+		process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id'
+		process.env.CLOUDFLARE_IMAGES_API_TOKEN = 'super-secret-token'
+		const fetchSpy = mockCloudflareUpload()
+
+		const first = await getPosterUrl('/poster.jpg')
+		const second = await getPosterUrl('/poster.jpg')
+
+		expect(first).toBe(CLOUDFLARE_URL)
+		expect(second).toBe(CLOUDFLARE_URL)
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+	})
+
+	test('Cloudflare returning a non-ok response falls back to the direct TMDB URL, not a throw', async() => {
+		process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id'
+		process.env.CLOUDFLARE_IMAGES_API_TOKEN = 'super-secret-token'
+		mockCloudflareUpload({ ok: false })
+
+		const url = await getPosterUrl('/poster.jpg')
+
+		expect(url).toBe(TMDB_DIRECT_URL)
+		expect(await ImageCache.findOne({ tmdbImagePath: '/poster.jpg' })).toBeNull()
+	})
+
+	test('Cloudflare API being down (network error) falls back to the direct TMDB URL, not a throw', async() => {
+		process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id'
+		process.env.CLOUDFLARE_IMAGES_API_TOKEN = 'super-secret-token'
+		jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network unreachable'))
+
+		await expect(getPosterUrl('/poster.jpg')).resolves.toBe(TMDB_DIRECT_URL)
+	})
+
+	test('a failed upload never logs or returns the API token', async() => {
+		process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id'
+		process.env.CLOUDFLARE_IMAGES_API_TOKEN = 'super-secret-token'
+		jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network unreachable'))
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+		const url = await getPosterUrl('/poster.jpg')
+
+		expect(url).not.toContain('super-secret-token')
+		for (const call of consoleErrorSpy.mock.calls) {
+			for (const argument of call) {
+				expect(String(argument)).not.toContain('super-secret-token')
+			}
+		}
+	})
+})

--- a/server/serializers/README.md
+++ b/server/serializers/README.md
@@ -34,3 +34,10 @@ these:
   shape, per the rule above.
 - `ConfigPublicDTO` exposes exactly `lowTrustBadgeThreshold` and
   `voteWeightFloor` — the two fields the rule above allowlists from `Config`.
+
+Built in Phase 4 (image service): `MovieSummaryDTO`/`MovieDetailsDTO`'s
+`poster_path`/`backdrop_path` are resolved through
+`server/lib/image-service.ts` before they leave this file — they are full,
+ready-to-use `<img src>` URLs, not TMDB-relative path fragments the way TMDB
+itself returns them. Any component consuming these fields should render them
+directly, not prepend a TMDB image base URL.

--- a/server/serializers/movies.ts
+++ b/server/serializers/movies.ts
@@ -3,7 +3,13 @@
  * "Standing Requirement — Data Minimization" in docs/plan).
  * Every field sent to the client is named here; anything TMDB adds
  * upstream is dropped unless deliberately allowlisted.
+ *
+ * poster_path/backdrop_path are resolved through server/lib/image-service.ts
+ * (Phase 4) — they are full, ready-to-use image URLs here, not the raw
+ * TMDB-relative paths TMDB itself returns.
  */
+
+import { getBackdropUrl, getPosterUrl } from '../lib/image-service'
 
 type TmdbPayload = Record<string, unknown>
 
@@ -67,13 +73,18 @@ export interface MovieImagesDTO {
 	posters: MovieImageDTO[]
 }
 
-export function toMovieSummaryDTO(movie: TmdbPayload): MovieSummaryDTO {
+export async function toMovieSummaryDTO(movie: TmdbPayload): Promise<MovieSummaryDTO> {
+	const [posterUrl, backdropUrl] = await Promise.all([
+		getPosterUrl((movie.poster_path as string) ?? null),
+		getBackdropUrl((movie.backdrop_path as string) ?? null)
+	])
+
 	return {
 		id: movie.id as number,
 		title: movie.title as string,
 		overview: movie.overview as string,
-		poster_path: (movie.poster_path as string) ?? null,
-		backdrop_path: (movie.backdrop_path as string) ?? null,
+		poster_path: posterUrl,
+		backdrop_path: backdropUrl,
 		release_date: movie.release_date as string,
 		vote_average: movie.vote_average as number,
 		vote_count: movie.vote_count as number,
@@ -81,13 +92,18 @@ export function toMovieSummaryDTO(movie: TmdbPayload): MovieSummaryDTO {
 	}
 }
 
-export function toMovieDetailsDTO(movie: TmdbPayload): MovieDetailsDTO {
+export async function toMovieDetailsDTO(movie: TmdbPayload): Promise<MovieDetailsDTO> {
+	const [posterUrl, backdropUrl] = await Promise.all([
+		getPosterUrl((movie.poster_path as string) ?? null),
+		getBackdropUrl((movie.backdrop_path as string) ?? null)
+	])
+
 	return {
 		id: movie.id as number,
 		title: movie.title as string,
 		overview: movie.overview as string,
-		poster_path: (movie.poster_path as string) ?? null,
-		backdrop_path: (movie.backdrop_path as string) ?? null,
+		poster_path: posterUrl,
+		backdrop_path: backdropUrl,
 		release_date: movie.release_date as string,
 		vote_average: movie.vote_average as number,
 		vote_count: movie.vote_count as number,
@@ -97,14 +113,14 @@ export function toMovieDetailsDTO(movie: TmdbPayload): MovieDetailsDTO {
 	}
 }
 
-export function toMovieListDTO(payload: TmdbPayload): MovieListDTO {
+export async function toMovieListDTO(payload: TmdbPayload): Promise<MovieListDTO> {
 	const results = (payload.results as TmdbPayload[]) ?? []
 
 	return {
 		page: payload.page as number,
 		total_pages: payload.total_pages as number,
 		total_results: payload.total_results as number,
-		results: results.map(toMovieSummaryDTO)
+		results: await Promise.all(results.map(toMovieSummaryDTO))
 	}
 }
 

--- a/server/serializers/tests/movies.test.js
+++ b/server/serializers/tests/movies.test.js
@@ -19,8 +19,8 @@ const tmdbMovie = {
 }
 
 describe('movie serializers allowlist', () => {
-	test('summary DTO drops non-allowlisted TMDB fields', () => {
-		const dto = toMovieSummaryDTO(tmdbMovie)
+	test('summary DTO drops non-allowlisted TMDB fields', async() => {
+		const dto = await toMovieSummaryDTO(tmdbMovie)
 
 		expect(Object.keys(dto).sort()).toEqual([
 			'backdrop_path', 'genre_ids', 'id', 'overview', 'poster_path',
@@ -29,8 +29,8 @@ describe('movie serializers allowlist', () => {
 		expect(dto.title).toBe('Fight Club')
 	})
 
-	test('details DTO drops non-allowlisted TMDB fields', () => {
-		const dto = toMovieDetailsDTO({
+	test('details DTO drops non-allowlisted TMDB fields', async() => {
+		const dto = await toMovieDetailsDTO({
 			...tmdbMovie, runtime: 139, tagline: 'Mischief.', genres: [{id: 18, name: 'Drama'}], budget: 63000000, imdb_id: 'tt0137523'
 		})
 
@@ -40,8 +40,8 @@ describe('movie serializers allowlist', () => {
 		])
 	})
 
-	test('list DTO shapes pagination and maps results', () => {
-		const dto = toMovieListDTO({
+	test('list DTO shapes pagination and maps results', async() => {
+		const dto = await toMovieListDTO({
 			page: 1, total_pages: 10, total_results: 200, results: [tmdbMovie], dates: {maximum: 'x', minimum: 'y'}
 		})
 


### PR DESCRIPTION
## Summary
- `server/lib/image-service.ts`: thin swappable-provider abstraction (`getPosterUrl`/`getBackdropUrl`) — proxies TMDB poster/backdrop images through Cloudflare Images instead of hitting TMDB's CDN raw
- `server/database/models/image-cache.ts`: persists TMDB path → Cloudflare URL mapping so a movie's images upload once, not on every request
- Every failure point (no Cloudflare credentials configured, DB not connected, non-ok response, thrown network error) falls back to the direct TMDB CDN URL — never throws, never a broken image
- Wired into `toMovieSummaryDTO`/`toMovieDetailsDTO`/`toMovieListDTO` (now async, callers in `actions/movies.ts` updated); left cast/crew headshots and the image-gallery endpoint alone — proxying every gallery image per request would fan out uncontrolled Cloudflare calls
- Cloudflare API token travels only in an `Authorization` header, never a URL or interpolated string — structurally can't leak the way the old TMDB `api_key` query param did; covered by a test asserting it never appears in a log line or return value
- `server/serializers/README.md` documents the new absolute-URL contract on `poster_path`/`backdrop_path` so it's discoverable when Phase 5 builds movie cards

## Requires manual setup (not doable from here)
Create a Cloudflare Images account (dashboard) and set as env vars, locally and in prod:
- `CLOUDFLARE_ACCOUNT_ID`
- `CLOUDFLARE_IMAGES_API_TOKEN`

Unset, the service degrades to direct TMDB URLs — same behavior as before this PR.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 54/54 passing, including new image-service tests: cache-hit vs cache-miss, not-configured fallback, non-ok-response fallback, network-error fallback, token-never-leaks