### PR TITLE
phase5/1: movie detail page with SSR loader + trailer embed

### DIFF
--- a/client/src/features/movies/movie-detail.tsx
+++ b/client/src/features/movies/movie-detail.tsx
@@ -1,0 +1,69 @@
+import { Badge, Container, Grid, Group, Text, Title } from '@mantine/core'
+import React from 'react'
+import type { MovieDetails, MovieVideos } from './types'
+
+function findTrailer(videos: MovieVideos) {
+  return (
+    videos.results.find(video => video.site === 'YouTube' && video.type === 'Trailer' && video.official) ??
+    videos.results.find(video => video.site === 'YouTube' && video.type === 'Trailer') ??
+    null
+  )
+}
+
+export default function MovieDetail({ movie, videos }: { movie: MovieDetails; videos: MovieVideos }) {
+  const trailer = findTrailer(videos)
+  const releaseYear = movie.release_date ? movie.release_date.slice(0, 4) : null
+
+  return (
+    <Container size="lg" py="lg">
+      <Grid gap="xl">
+        <Grid.Col span={{ base: 12, sm: 4 }}>
+          {movie.poster_path ? (
+            <img
+              src={movie.poster_path}
+              alt={movie.title}
+              style={{ width: '100%', borderRadius: 'var(--mantine-radius-md)' }}
+            />
+          ) : null}
+        </Grid.Col>
+
+        <Grid.Col span={{ base: 12, sm: 8 }}>
+          <Title order={1}>{movie.title}</Title>
+
+          <Group gap="xs" mt="xs">
+            {releaseYear ? <Text c="dimmed">{releaseYear}</Text> : null}
+            {movie.runtime ? <Text c="dimmed">{movie.runtime} min</Text> : null}
+            <Badge variant="light">{movie.vote_average.toFixed(1)} / 10</Badge>
+          </Group>
+
+          {movie.tagline ? (
+            <Text fs="italic" c="dimmed" mt="sm">{movie.tagline}</Text>
+          ) : null}
+
+          <Group gap="xs" mt="sm">
+            {movie.genres.map(genre => (
+              <Badge key={genre.id} variant="outline">{genre.name}</Badge>
+            ))}
+          </Group>
+
+          <Text mt="md">{movie.overview}</Text>
+
+          {trailer ? (
+            <div style={{ marginTop: 'var(--mantine-spacing-lg)' }}>
+              <Title order={3} mb="sm">Trailer</Title>
+              <div style={{ position: 'relative', width: '100%', aspectRatio: '16 / 9' }}>
+                <iframe
+                  src={`https://www.youtube.com/embed/${trailer.key}`}
+                  title={trailer.name}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
+                />
+              </div>
+            </div>
+          ) : null}
+        </Grid.Col>
+      </Grid>
+    </Container>
+  )
+}

--- a/client/src/features/movies/movies.tsx
+++ b/client/src/features/movies/movies.tsx
@@ -1,21 +1,36 @@
+import { Container, SimpleGrid, Title } from '@mantine/core'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import MovieCard from '../../ui/movie-card'
 import type { MovieList } from './types'
-import './styles.css'
 
-export default function Movies({ moviesData }: { moviesData: MovieList }) {
-  const { t } = useTranslation()
+function releaseYear(releaseDate: string): string | null {
+	return releaseDate ? releaseDate.slice(0, 4) : null
+}
 
-  return (
-    <div className="main_div">
-      <h4>{t('header.test')}</h4>
-      <ul>
-        {moviesData.results.map(movie => (
-          <li key={movie.id}>
-            {movie.title} ({movie.release_date?.slice(0, 4)})
-          </li>
-        ))}
-      </ul>
-    </div>
-  )
+function MovieGrid({ movieList }: { movieList: MovieList }) {
+	return (
+		<SimpleGrid cols={{ base: 2, sm: 3, md: 5 }}>
+			{movieList.results.map(movie => (
+				<MovieCard
+					key={movie.id}
+					id={movie.id}
+					title={movie.title}
+					posterUrl={movie.poster_path}
+					releaseYear={releaseYear(movie.release_date)}
+				/>
+			))}
+		</SimpleGrid>
+	)
+}
+
+export default function Movies({ popular, upcoming }: { popular: MovieList; upcoming: MovieList }) {
+	return (
+		<Container size="xl" py="lg">
+			<Title order={2} mb="md">Popular</Title>
+			<MovieGrid movieList={popular} />
+
+			<Title order={2} mt="xl" mb="md">Upcoming</Title>
+			<MovieGrid movieList={upcoming} />
+		</Container>
+	)
 }

--- a/client/src/features/movies/types.ts
+++ b/client/src/features/movies/types.ts
@@ -16,3 +16,31 @@ export interface MovieList {
   total_results: number
   results: MovieSummary[]
 }
+
+export interface MovieDetails {
+  id: number
+  title: string
+  overview: string
+  poster_path: string | null
+  backdrop_path: string | null
+  release_date: string
+  vote_average: number
+  vote_count: number
+  runtime: number | null
+  tagline: string
+  genres: Array<{ id: number; name: string }>
+}
+
+export interface MovieVideo {
+  id: string
+  key: string
+  site: string
+  type: string
+  name: string
+  official: boolean
+}
+
+export interface MovieVideos {
+  id: number
+  results: MovieVideo[]
+}

--- a/client/src/routes/_index.tsx
+++ b/client/src/routes/_index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import '../features/movies/styles.css'
 
 export default function Home() {
   return (

--- a/client/src/routes/movies.$movieId.tsx
+++ b/client/src/routes/movies.$movieId.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import MovieDetail from '../features/movies/movie-detail'
+import type { MovieDetails, MovieVideos } from '../features/movies/types'
+import type { Route } from './+types/movies.$movieId'
+
+const API_URL = process.env.API_URL ?? 'http://localhost:5000'
+
+interface MovieDetailLoaderData {
+	movie: MovieDetails
+	videos: MovieVideos
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+	if (!loaderData) {
+		return [{ title: 'Movie not found — criticseven' }]
+	}
+
+	return [
+		{ title: `${loaderData.movie.title} — criticseven` },
+		{ name: 'description', content: loaderData.movie.overview }
+	]
+}
+
+export async function loader({ params }: Route.LoaderArgs): Promise<MovieDetailLoaderData> {
+	const [movieResponse, videosResponse] = await Promise.all([
+		fetch(`${API_URL}/movies/details?movieId=${params.movieId}`),
+		fetch(`${API_URL}/movies/videos?movieId=${params.movieId}`)
+	])
+
+	if (!movieResponse.ok) {
+		throw new Response('Movie not found', { status: movieResponse.status === 404 ? 404 : 502 })
+	}
+
+	const movie = (await movieResponse.json()) as MovieDetails
+	// A missing/broken videos response degrades to "no trailer" rather than
+	// failing the whole page — the movie's own details are the page's reason
+	// to exist, the trailer is a bonus.
+	const videos = videosResponse.ok ? ((await videosResponse.json()) as MovieVideos) : { id: movie.id, results: [] }
+
+	return { movie, videos }
+}
+
+export default function MovieDetailRoute({ loaderData }: Route.ComponentProps) {
+	return <MovieDetail movie={loaderData.movie} videos={loaderData.videos} />
+}

--- a/client/src/routes/movies.tsx
+++ b/client/src/routes/movies.tsx
@@ -5,16 +5,33 @@ import type { Route } from './+types/movies'
 
 const API_URL = process.env.API_URL ?? 'http://localhost:5000'
 
-export async function loader(): Promise<MovieList> {
-  const response = await fetch(`${API_URL}/movies/popular`)
+interface MoviesLoaderData {
+  popular: MovieList
+  upcoming: MovieList
+}
 
-  if (!response.ok) {
+export function meta() {
+  return [
+    { title: 'Movies — criticseven' },
+    { name: 'description', content: 'Popular and upcoming movies.' }
+  ]
+}
+
+export async function loader(): Promise<MoviesLoaderData> {
+  const [popularResponse, upcomingResponse] = await Promise.all([
+    fetch(`${API_URL}/movies/popular`),
+    fetch(`${API_URL}/movies/upcoming`)
+  ])
+
+  if (!popularResponse.ok || !upcomingResponse.ok) {
     throw new Response('Failed to load movies', { status: 502 })
   }
 
-  return response.json()
+  const [popular, upcoming] = await Promise.all([popularResponse.json(), upcomingResponse.json()])
+
+  return { popular, upcoming }
 }
 
 export default function MoviesRoute({ loaderData }: Route.ComponentProps) {
-  return <Movies moviesData={loaderData} />
+  return <Movies popular={loaderData.popular} upcoming={loaderData.upcoming} />
 }

--- a/client/src/ui/movie-card.tsx
+++ b/client/src/ui/movie-card.tsx
@@ -1,0 +1,46 @@
+import { Card, Text } from '@mantine/core'
+import React from 'react'
+import { Link } from 'react-router'
+
+export interface MovieCardProps {
+	id: number
+	title: string
+	posterUrl: string | null
+	releaseYear: string | null
+}
+
+// Deliberately typed on a minimal shape (not features/movies' MovieSummary)
+// so this stays reusable without ui/ importing from features/ — see
+// client/src/ui/README.md.
+export default function MovieCard({ id, title, posterUrl, releaseYear }: MovieCardProps) {
+	return (
+		<Card component={Link} to={`/movies/${id}`} withBorder padding="sm" radius="md">
+			<Card.Section>
+				{posterUrl ? (
+					<img src={posterUrl} alt={title} style={{ width: '100%', aspectRatio: '2 / 3', objectFit: 'cover' }} />
+				) : (
+					<div
+						style={{
+							width: '100%',
+							aspectRatio: '2 / 3',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							background: 'var(--mantine-color-gray-2)'
+						}}
+					>
+						<Text size="sm" c="dimmed">No poster</Text>
+					</div>
+				)}
+			</Card.Section>
+			<Text fw={500} mt="sm" lineClamp={2}>
+				{title}
+			</Text>
+			{releaseYear ? (
+				<Text size="sm" c="dimmed">
+					{releaseYear}
+				</Text>
+			) : null}
+		</Card>
+	)
+}

--- a/server/actions/movies.ts
+++ b/server/actions/movies.ts
@@ -1,6 +1,6 @@
 import {NextFunction, Request, Response} from 'express'
 import {
-	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO
+	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO, toMovieVideosDTO
 } from '../serializers'
 import {TmdbMovie} from '../tmdb-wrapper'
 
@@ -71,6 +71,16 @@ export const getImages = async(request: Request, response: Response, next: NextF
 		const movieImages = await Tmdb.getMovieImages(String(request.query.movieId))
 
 		response.send(toMovieImagesDTO(movieImages))
+	} catch (error) {
+		next(error)
+	}
+}
+
+export const getVideos = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const movieVideos = await Tmdb.getMovieVideos(String(request.query.movieId))
+
+		response.send(toMovieVideosDTO(movieVideos))
 	} catch (error) {
 		next(error)
 	}

--- a/server/routes/movie-routes.ts
+++ b/server/routes/movie-routes.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import {
-	getCredits, getDetails, getImages, getLatest, getNowPlaying, getPopular, getUpcoming
+	getCredits, getDetails, getImages, getLatest, getNowPlaying, getPopular, getUpcoming, getVideos
 } from '../actions'
 
 const movieRoutes = () => {
@@ -8,6 +8,7 @@ const movieRoutes = () => {
 
 	router.get('/credits', getCredits)
 	router.get('/images', getImages)
+	router.get('/videos', getVideos)
 	router.get('/details', getDetails)
 	router.get('/upcoming', getUpcoming)
 	router.get('/playing', getNowPlaying)

--- a/server/serializers/movies.ts
+++ b/server/serializers/movies.ts
@@ -73,6 +73,20 @@ export interface MovieImagesDTO {
 	posters: MovieImageDTO[]
 }
 
+export interface MovieVideoDTO {
+	id: string
+	key: string
+	site: string
+	type: string
+	name: string
+	official: boolean
+}
+
+export interface MovieVideosDTO {
+	id: number
+	results: MovieVideoDTO[]
+}
+
 export async function toMovieSummaryDTO(movie: TmdbPayload): Promise<MovieSummaryDTO> {
 	const [posterUrl, backdropUrl] = await Promise.all([
 		getPosterUrl((movie.poster_path as string) ?? null),
@@ -162,5 +176,26 @@ export function toMovieImagesDTO(payload: TmdbPayload): MovieImagesDTO {
 		id: payload.id as number,
 		backdrops: ((payload.backdrops as TmdbPayload[]) ?? []).map(toMovieImageDTO),
 		posters: ((payload.posters as TmdbPayload[]) ?? []).map(toMovieImageDTO)
+	}
+}
+
+function toMovieVideoDTO(video: TmdbPayload): MovieVideoDTO {
+	return {
+		id: video.id as string,
+		key: video.key as string,
+		site: video.site as string,
+		type: video.type as string,
+		name: video.name as string,
+		official: (video.official as boolean) ?? false
+	}
+}
+
+// Movie.trailerUrl (the app's own field, docs/plan Phase 5 item 1) is the
+// primary trailer source once something populates it; this stays as the
+// fallback for movies that don't have one yet.
+export function toMovieVideosDTO(payload: TmdbPayload): MovieVideosDTO {
+	return {
+		id: payload.id as number,
+		results: ((payload.results as TmdbPayload[]) ?? []).map(toMovieVideoDTO)
 	}
 }

--- a/server/serializers/tests/movies.test.js
+++ b/server/serializers/tests/movies.test.js
@@ -1,5 +1,5 @@
 import {
-	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO, toMovieSummaryDTO
+	toMovieCreditsDTO, toMovieDetailsDTO, toMovieImagesDTO, toMovieListDTO, toMovieSummaryDTO, toMovieVideosDTO
 } from '../movies'
 
 const tmdbMovie = {
@@ -75,5 +75,19 @@ describe('movie serializers allowlist', () => {
 
 		expect(Object.keys(dto.backdrops[0]).sort()).toEqual(['aspect_ratio', 'file_path', 'height', 'width'])
 		expect(dto.posters).toEqual([])
+	})
+
+	test('videos DTO allowlists video entries and tolerates a missing array', () => {
+		const dto = toMovieVideosDTO({
+			id: 550,
+			results: [{
+				id: '5c9294240e0a267cd516835f', key: 'SUXWAEX2jlg', site: 'YouTube', type: 'Trailer', name: 'Official Trailer', official: true, iso_639_1: 'en', iso_3166_1: 'US', size: 1080, published_at: '2016-08-03T00:00:00.000Z'
+			}]
+		})
+
+		expect(Object.keys(dto.results[0]).sort()).toEqual(['id', 'key', 'name', 'official', 'site', 'type'])
+		expect(dto.results[0].key).toBe('SUXWAEX2jlg')
+
+		expect(toMovieVideosDTO({ id: 550 }).results).toEqual([])
 	})
 })

--- a/server/tmdb-wrapper/movie-db-wrapper.ts
+++ b/server/tmdb-wrapper/movie-db-wrapper.ts
@@ -70,4 +70,12 @@ export default class TmdbMovie {
 
     return data
   }
+
+  async getMovieVideos(movieId: string) {
+    const { data } = await axios.get(
+      `${apiBaseURL}/movie/${movieId}/videos?api_key=${this.apiKey}&language=${this.language}`
+    )
+
+    return data
+  }
 }

--- a/server/tmdb-wrapper/tests/mock-data.js
+++ b/server/tmdb-wrapper/tests/mock-data.js
@@ -100,6 +100,24 @@ export const fakeImageInfo = {
 	]
 }
 
+export const fakeVideos = {
+	"id": 550,
+	"results": [
+		{
+			"iso_639_1": "en",
+			"iso_3166_1": "US",
+			"name": "Official Trailer",
+			"key": "SUXWAEX2jlg",
+			"site": "YouTube",
+			"size": 1080,
+			"type": "Trailer",
+			"official": true,
+			"published_at": "2016-08-03T00:00:00.000Z",
+			"id": "5c9294240e0a267cd516835f"
+		}
+	]
+}
+
 export const fakeCredits ={
 	"id": 222,
 	"cast": [

--- a/server/tmdb-wrapper/tests/movie-wrapper.test.js
+++ b/server/tmdb-wrapper/tests/movie-wrapper.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import TmdbMovie from '../movie-db-wrapper'
 import {
-	API_KEY, fakeCredits, fakeImageInfo, fakeMovie, fakeMovieList
+	API_KEY, fakeCredits, fakeImageInfo, fakeMovie, fakeMovieList, fakeVideos
 } from './mock-data'
 
 jest.mock('axios')
@@ -95,6 +95,19 @@ describe('Should test the retrieval of required movie information', () => {
 		const movieCredit = await Tmdb.getMovieCredits()
 
 		expect(movieCredit).toEqual(fakeCredits)
+	})
+
+	test('should fetch movie videos', async() => {
+		const response = {
+			data: fakeVideos
+		}
+
+		axios.get.mockResolvedValue(response)
+		const Tmdb = new TmdbMovie(API_KEY)
+
+		const movieVideos = await Tmdb.getMovieVideos()
+
+		expect(movieVideos).toEqual(fakeVideos)
 	})
 })
 


### PR DESCRIPTION
## Summary
- Movie detail page (`movie-detail.tsx`, `movies.$movieId.tsx`) with SSR loader and trailer embed
- Movie listing refactored to use new `movie-card.tsx` component
- New videos endpoint/DTO/action wired through server actions, routes, and serializers
- TMDB wrapper extended to fetch video data; mock data and tests updated accordingly

## Note
SSR verified structurally only (loader wiring, types, serializer shape). Live curl check against the real TMDB endpoint is pending — needs a run with a real `API_KEY` locally before merge.

## Test plan
- [ ] Run server locally with real `API_KEY`, curl the movie detail SSR route, confirm trailer data renders
- [ ] Spot-check movie listing cards render correctly
- [x] `server/serializers/tests/movies.test.js` and `server/tmdb-wrapper/tests/movie-wrapper.test.js` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate Popular and Upcoming movie sections with responsive card layouts.
  * Added clickable movie cards linking to detailed movie pages.
  * Added movie detail pages with posters, release year, tagline, runtime, genres, overview, and ratings information.
  * Added embedded official or fallback trailers when available.
  * Added page titles and descriptions for improved browser and search visibility.

* **Bug Fixes**
  * Movie details remain available when trailer data cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->