### PR TITLE
phase5/3: voting + honesty score

### DIFF
--- a/client/src/features/movies/movie-detail.tsx
+++ b/client/src/features/movies/movie-detail.tsx
@@ -13,13 +13,14 @@ function findTrailer(videos: MovieVideos) {
 }
 
 export default function MovieDetail({
-  movie, videos, opinions, reviews, isAuthenticated
+  movie, videos, opinions, reviews, isAuthenticated, currentUsername
 }: {
   movie: MovieDetails
   videos: MovieVideos
   opinions: PaginatedList<OpinionSummary>
   reviews: PaginatedList<ReviewSummary>
   isAuthenticated: boolean
+  currentUsername: string | null
 }) {
   const trailer = findTrailer(videos)
   const releaseYear = movie.release_date ? movie.release_date.slice(0, 4) : null
@@ -75,8 +76,8 @@ export default function MovieDetail({
         </Grid.Col>
       </Grid>
 
-      <OpinionSection opinions={opinions} isAuthenticated={isAuthenticated} />
-      <ReviewSection reviews={reviews} isAuthenticated={isAuthenticated} />
+      <OpinionSection opinions={opinions} isAuthenticated={isAuthenticated} currentUsername={currentUsername} />
+      <ReviewSection reviews={reviews} isAuthenticated={isAuthenticated} currentUsername={currentUsername} />
     </Container>
   )
 }

--- a/client/src/features/movies/opinion-section.tsx
+++ b/client/src/features/movies/opinion-section.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Form, Link, useActionData, useNavigation } from 'react-router'
 import LowTrustBadge from '../../ui/low-trust-badge'
 import RatingInput from '../../ui/rating-input'
+import VoteButtons from '../../ui/vote-buttons'
 import type { OpinionSummary, PaginatedList } from './types'
 
 interface SubmissionResult {
@@ -31,7 +32,13 @@ function OpinionForm() {
   )
 }
 
-function OpinionList({ opinions }: { opinions: OpinionSummary[] }) {
+function OpinionList(
+  { opinions, isAuthenticated, currentUsername }: {
+    opinions: OpinionSummary[]
+    isAuthenticated: boolean
+    currentUsername: string | null
+  }
+) {
   if (opinions.length === 0) {
     return (
       <Text c="dimmed" size="sm">
@@ -44,10 +51,22 @@ function OpinionList({ opinions }: { opinions: OpinionSummary[] }) {
     <Stack gap="sm">
       {opinions.map(opinion => (
         <Card key={opinion.id} withBorder padding="sm" radius="md">
-          <Group gap="xs">
-            <Text fw={500}>{opinion.author.username}</Text>
-            {opinion.author.isLowTrust ? <LowTrustBadge /> : null}
-            <Badge variant="light" color="orange">Hype {opinion.hypeLevel}/5</Badge>
+          <Group gap="xs" justify="space-between">
+            <Group gap="xs">
+              <Text fw={500}>{opinion.author.username}</Text>
+              {opinion.author.isLowTrust ? <LowTrustBadge /> : null}
+              <Text size="sm" c="dimmed">Honesty {opinion.author.honestyScore}</Text>
+              <Badge variant="light" color="orange">Hype {opinion.hypeLevel}/5</Badge>
+            </Group>
+            {opinion.author.username === currentUsername ? null : (
+              <VoteButtons
+                targetType="opinion"
+                targetId={opinion.id}
+                netVoteCount={opinion.netVoteCount}
+                viewerVote={opinion.viewerVote}
+                isAuthenticated={isAuthenticated}
+              />
+            )}
           </Group>
           {opinion.comment ? <Text size="sm" mt="xs">{opinion.comment}</Text> : null}
         </Card>
@@ -57,7 +76,11 @@ function OpinionList({ opinions }: { opinions: OpinionSummary[] }) {
 }
 
 export default function OpinionSection(
-  { opinions, isAuthenticated }: { opinions: PaginatedList<OpinionSummary>; isAuthenticated: boolean }
+  { opinions, isAuthenticated, currentUsername }: {
+    opinions: PaginatedList<OpinionSummary>
+    isAuthenticated: boolean
+    currentUsername: string | null
+  }
 ) {
   return (
     <Stack gap="md" mt="xl">
@@ -75,7 +98,7 @@ export default function OpinionSection(
         </Text>
       )}
 
-      <OpinionList opinions={opinions.results} />
+      <OpinionList opinions={opinions.results} isAuthenticated={isAuthenticated} currentUsername={currentUsername} />
     </Stack>
   )
 }

--- a/client/src/features/movies/review-section.tsx
+++ b/client/src/features/movies/review-section.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Form, Link, useActionData, useNavigation } from 'react-router'
 import LowTrustBadge from '../../ui/low-trust-badge'
 import RatingInput from '../../ui/rating-input'
+import VoteButtons from '../../ui/vote-buttons'
 import type { PaginatedList, ReviewSummary } from './types'
 
 interface SubmissionResult {
@@ -45,7 +46,13 @@ function ReviewForm() {
   )
 }
 
-function ReviewList({ reviews }: { reviews: ReviewSummary[] }) {
+function ReviewList(
+  { reviews, isAuthenticated, currentUsername }: {
+    reviews: ReviewSummary[]
+    isAuthenticated: boolean
+    currentUsername: string | null
+  }
+) {
   if (reviews.length === 0) {
     return (
       <Text c="dimmed" size="sm">
@@ -58,10 +65,22 @@ function ReviewList({ reviews }: { reviews: ReviewSummary[] }) {
     <Stack gap="sm">
       {reviews.map(review => (
         <Card key={review.id} withBorder padding="sm" radius="md">
-          <Group gap="xs">
-            <Text fw={500}>{review.author.username}</Text>
-            {review.author.isLowTrust ? <LowTrustBadge /> : null}
-            <Badge variant="light" color="teal">Score {review.score}/10</Badge>
+          <Group gap="xs" justify="space-between">
+            <Group gap="xs">
+              <Text fw={500}>{review.author.username}</Text>
+              {review.author.isLowTrust ? <LowTrustBadge /> : null}
+              <Text size="sm" c="dimmed">Honesty {review.author.honestyScore}</Text>
+              <Badge variant="light" color="teal">Score {review.score}/10</Badge>
+            </Group>
+            {review.author.username === currentUsername ? null : (
+              <VoteButtons
+                targetType="review"
+                targetId={review.id}
+                netVoteCount={review.netVoteCount}
+                viewerVote={review.viewerVote}
+                isAuthenticated={isAuthenticated}
+              />
+            )}
           </Group>
           <Group gap="xs" mt="xs">
             {CRITERIA.filter(criterion => criterion.name !== 'score').map(criterion => (
@@ -78,7 +97,11 @@ function ReviewList({ reviews }: { reviews: ReviewSummary[] }) {
 }
 
 export default function ReviewSection(
-  { reviews, isAuthenticated }: { reviews: PaginatedList<ReviewSummary>; isAuthenticated: boolean }
+  { reviews, isAuthenticated, currentUsername }: {
+    reviews: PaginatedList<ReviewSummary>
+    isAuthenticated: boolean
+    currentUsername: string | null
+  }
 ) {
   return (
     <Stack gap="md" mt="xl">
@@ -96,7 +119,7 @@ export default function ReviewSection(
         </Text>
       )}
 
-      <ReviewList reviews={reviews.results} />
+      <ReviewList reviews={reviews.results} isAuthenticated={isAuthenticated} currentUsername={currentUsername} />
     </Stack>
   )
 }

--- a/client/src/features/movies/types.ts
+++ b/client/src/features/movies/types.ts
@@ -58,6 +58,8 @@ export interface OpinionSummary {
   author: AuthorSummary
   hypeLevel: number
   comment: string
+  netVoteCount: number
+  viewerVote: 1 | -1 | null
   createdAt: string
 }
 
@@ -73,6 +75,8 @@ export interface ReviewSummary {
   editing: number
   cinematography: number
   comment: string
+  netVoteCount: number
+  viewerVote: 1 | -1 | null
   createdAt: string
 }
 

--- a/client/src/routes/movies.$movieId.tsx
+++ b/client/src/routes/movies.$movieId.tsx
@@ -17,10 +17,11 @@ interface MovieDetailLoaderData {
 	opinions: PaginatedList<OpinionSummary>
 	reviews: PaginatedList<ReviewSummary>
 	isAuthenticated: boolean
+	currentUsername: string | null
 }
 
 interface SubmissionResult {
-	intent: 'opinion' | 'review'
+	intent: 'opinion' | 'review' | 'vote' | 'unvote'
 	error: string
 }
 
@@ -58,7 +59,14 @@ export async function loader({ request, params }: Route.LoaderArgs): Promise<Mov
 		: EMPTY_LIST
 	const reviews = reviewsResponse.ok ? ((await reviewsResponse.json()) as PaginatedList<ReviewSummary>) : EMPTY_LIST
 
-	return { movie, videos, opinions, reviews, isAuthenticated: Boolean(session.get('userId')) }
+	return {
+		movie,
+		videos,
+		opinions,
+		reviews,
+		isAuthenticated: Boolean(session.get('userId')),
+		currentUsername: session.get('username') ?? null
+	}
 }
 
 // requireSession is a fast local fail: no network round trip for an
@@ -120,6 +128,54 @@ export async function action({ request, params }: Route.ActionArgs): Promise<Res
 		return redirect(request.url)
 	}
 
+	if (intent === 'vote') {
+		// Fetcher-driven (client/src/ui/vote-buttons.tsx), not a full-page
+		// <Form> submission — no redirect() here, the fetcher revalidates the
+		// loader itself once this resolves.
+		const upstream = await fetch(`${API_URL}/votes`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Cookie: cookie },
+			body: JSON.stringify({
+				targetType: formData.get('targetType'),
+				targetId: formData.get('targetId'),
+				voteValue: Number(formData.get('voteValue'))
+			})
+		})
+
+		if (!upstream.ok) {
+			const body = (await upstream.json()) as { error: { message: string } }
+
+			return Response.json({ intent: 'vote', error: body.error.message } satisfies SubmissionResult, {
+				status: upstream.status
+			})
+		}
+
+		return Response.json({ intent: 'vote', error: '' } satisfies SubmissionResult, { status: 200 })
+	}
+
+	if (intent === 'unvote') {
+		// Standard toggle-off: tapping the already-active vote button removes
+		// it instead of re-submitting the same value (client/src/ui/vote-buttons.tsx).
+		const upstream = await fetch(`${API_URL}/votes`, {
+			method: 'DELETE',
+			headers: { 'Content-Type': 'application/json', Cookie: cookie },
+			body: JSON.stringify({
+				targetType: formData.get('targetType'),
+				targetId: formData.get('targetId')
+			})
+		})
+
+		if (!upstream.ok) {
+			const body = (await upstream.json()) as { error: { message: string } }
+
+			return Response.json({ intent: 'unvote', error: body.error.message } satisfies SubmissionResult, {
+				status: upstream.status
+			})
+		}
+
+		return Response.json({ intent: 'unvote', error: '' } satisfies SubmissionResult, { status: 200 })
+	}
+
 	throw new Response('Unknown form submission', { status: 400 })
 }
 
@@ -131,6 +187,7 @@ export default function MovieDetailRoute({ loaderData }: Route.ComponentProps) {
 			opinions={loaderData.opinions}
 			reviews={loaderData.reviews}
 			isAuthenticated={loaderData.isAuthenticated}
+			currentUsername={loaderData.currentUsername}
 		/>
 	)
 }

--- a/client/src/ui/vote-buttons.tsx
+++ b/client/src/ui/vote-buttons.tsx
@@ -1,0 +1,83 @@
+import { ActionIcon, Group, Text } from '@mantine/core'
+import React from 'react'
+import { useFetcher, useNavigate } from 'react-router'
+
+export interface VoteButtonsProps {
+  targetType: 'opinion' | 'review'
+  targetId: string
+  netVoteCount: number
+  viewerVote: 1 | -1 | null
+  isAuthenticated: boolean
+}
+
+interface VoteActionData {
+  intent: 'vote' | 'unvote'
+  error?: string
+}
+
+// Voting is JS-driven (useFetcher), unlike the opinion/review forms — the
+// task calls for optimistic UI here specifically, so this component doesn't
+// carry a no-JS fallback the way client/src/ui/rating-input.tsx does.
+export default function VoteButtons({ targetType, targetId, netVoteCount, viewerVote, isAuthenticated }: VoteButtonsProps) {
+  const fetcher = useFetcher<VoteActionData>()
+  const navigate = useNavigate()
+
+  const isPendingForThisTarget = fetcher.state !== 'idle' && fetcher.formData?.get('targetId') === targetId
+  const pendingIntent = isPendingForThisTarget ? fetcher.formData?.get('intent') : null
+
+  // What viewerVote will become once this in-flight submission lands —
+  // 'unvote' clears it, 'vote' sets it to the value being submitted, and
+  // with nothing pending it's just whatever the server last reported.
+  const optimisticViewerVote: 1 | -1 | null = pendingIntent === 'unvote'
+    ? null
+    : pendingIntent === 'vote'
+      ? (Number(fetcher.formData?.get('voteValue')) as 1 | -1)
+      : viewerVote
+  const optimisticNetVoteCount = netVoteCount + ((optimisticViewerVote ?? 0) - (viewerVote ?? 0))
+
+  function vote(clickedValue: 1 | -1) {
+    if (!isAuthenticated) {
+      navigate('/login')
+      return
+    }
+
+    // Tapping the already-active button removes the vote (standard
+    // upvote/downvote toggle behavior) instead of re-submitting it.
+    if (viewerVote === clickedValue) {
+      fetcher.submit({ intent: 'unvote', targetType, targetId }, { method: 'post' })
+      return
+    }
+
+    fetcher.submit(
+      { intent: 'vote', targetType, targetId, voteValue: String(clickedValue) },
+      { method: 'post' }
+    )
+  }
+
+  return (
+    <Group gap={4}>
+      <ActionIcon
+        variant={optimisticViewerVote === 1 ? 'filled' : 'subtle'}
+        color={optimisticViewerVote === 1 ? 'orange' : 'gray'}
+        aria-label="Upvote"
+        aria-pressed={optimisticViewerVote === 1}
+        onClick={() => vote(1)}
+      >
+        ▲
+      </ActionIcon>
+      <Text size="sm" fw={500} miw={20} ta="center">
+        {optimisticNetVoteCount}
+      </Text>
+      <ActionIcon
+        variant={optimisticViewerVote === -1 ? 'filled' : 'subtle'}
+        color={optimisticViewerVote === -1 ? 'blue' : 'gray'}
+        aria-label="Downvote"
+        aria-pressed={optimisticViewerVote === -1}
+        onClick={() => vote(-1)}
+      >
+        ▼
+      </ActionIcon>
+      {fetcher.data?.error ? <Text c="red" size="xs">{fetcher.data.error}</Text> : null}
+    </Group>
+  )
+}

--- a/server/actions/index.ts
+++ b/server/actions/index.ts
@@ -1,3 +1,4 @@
 export * from './movies'
 export * from './opinions'
 export * from './reviews'
+export * from './votes'

--- a/server/actions/opinions.ts
+++ b/server/actions/opinions.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import { TrailerOpinion } from '../database/models/trailer-opinion'
 import { getConfig } from '../lib/config'
 import { isDuplicateKeyError } from '../lib/mongo-errors'
+import { getVoteSummaries, VoteSummary } from '../lib/vote-counts'
 import { PopulatedTrailerOpinionDocument, toTrailerOpinionPublicDTO } from '../serializers'
 import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
 
@@ -52,8 +53,13 @@ export const createOpinion = async(request: Request, response: Response, next: N
 
 		const config = await getConfig()
 
+		const emptyVoteSummary: VoteSummary = { netVoteCount: 0, viewerVote: null }
+
 		response.status(201).json(
-			toTrailerOpinionPublicDTO(opinion as unknown as PopulatedTrailerOpinionDocument, config.lowTrustBadgeThreshold)
+			// A freshly created opinion has no votes yet.
+			toTrailerOpinionPublicDTO(
+				opinion as unknown as PopulatedTrailerOpinionDocument, emptyVoteSummary, config.lowTrustBadgeThreshold
+			)
 		)
 	} catch (error) {
 		// Unique index on (userId, movieId) — one opinion per user per movie.
@@ -81,6 +87,9 @@ export const getMovieOpinions = async(request: Request, response: Response, next
 
 		const page = Math.max(1, Math.trunc(Number(request.query.page)) || 1)
 		const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, Math.trunc(Number(request.query.limit)) || DEFAULT_PAGE_SIZE))
+		// Public endpoint — no cookie means no viewer identity, not a 401;
+		// it just means every viewerVote in the response comes back null.
+		const viewerId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
 
 		const [opinions, totalResults, config] = await Promise.all([
 			TrailerOpinion.find({ movieId })
@@ -91,13 +100,18 @@ export const getMovieOpinions = async(request: Request, response: Response, next
 			TrailerOpinion.countDocuments({ movieId }),
 			getConfig()
 		])
+		const voteSummaries = await getVoteSummaries('opinion', opinions.map(opinion => opinion._id), viewerId)
 
 		response.json({
 			page,
 			totalPages: Math.max(1, Math.ceil(totalResults / pageSize)),
 			totalResults,
 			results: (opinions as unknown as PopulatedTrailerOpinionDocument[]).map(
-				opinion => toTrailerOpinionPublicDTO(opinion, config.lowTrustBadgeThreshold)
+				opinion => toTrailerOpinionPublicDTO(
+					opinion,
+					voteSummaries.get(opinion.id) ?? { netVoteCount: 0, viewerVote: null },
+					config.lowTrustBadgeThreshold
+				)
 			)
 		})
 	} catch (error) {

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import { Review } from '../database/models/review'
 import { getConfig } from '../lib/config'
 import { isDuplicateKeyError } from '../lib/mongo-errors'
+import { getVoteSummaries, VoteSummary } from '../lib/vote-counts'
 import { PopulatedReviewDocument, toReviewPublicDTO } from '../serializers'
 import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
 
@@ -80,8 +81,11 @@ export const createReview = async(request: Request, response: Response, next: Ne
 
 		const config = await getConfig()
 
+		const emptyVoteSummary: VoteSummary = { netVoteCount: 0, viewerVote: null }
+
 		response.status(201).json(
-			toReviewPublicDTO(review as unknown as PopulatedReviewDocument, config.lowTrustBadgeThreshold)
+			// A freshly created review has no votes yet.
+			toReviewPublicDTO(review as unknown as PopulatedReviewDocument, emptyVoteSummary, config.lowTrustBadgeThreshold)
 		)
 	} catch (error) {
 		// Unique index on (userId, movieId) — one review per user per movie.
@@ -109,6 +113,9 @@ export const getMovieReviews = async(request: Request, response: Response, next:
 
 		const page = Math.max(1, Math.trunc(Number(request.query.page)) || 1)
 		const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, Math.trunc(Number(request.query.limit)) || DEFAULT_PAGE_SIZE))
+		// Public endpoint — no cookie means no viewer identity, not a 401;
+		// it just means every viewerVote in the response comes back null.
+		const viewerId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
 
 		const [reviews, totalResults, config] = await Promise.all([
 			Review.find({ movieId })
@@ -119,13 +126,18 @@ export const getMovieReviews = async(request: Request, response: Response, next:
 			Review.countDocuments({ movieId }),
 			getConfig()
 		])
+		const voteSummaries = await getVoteSummaries('review', reviews.map(review => review._id), viewerId)
 
 		response.json({
 			page,
 			totalPages: Math.max(1, Math.ceil(totalResults / pageSize)),
 			totalResults,
 			results: (reviews as unknown as PopulatedReviewDocument[]).map(
-				review => toReviewPublicDTO(review, config.lowTrustBadgeThreshold)
+				review => toReviewPublicDTO(
+					review,
+					voteSummaries.get(review.id) ?? { netVoteCount: 0, viewerVote: null },
+					config.lowTrustBadgeThreshold
+				)
 			)
 		})
 	} catch (error) {

--- a/server/actions/tests/opinions.test.ts
+++ b/server/actions/tests/opinions.test.ts
@@ -98,7 +98,7 @@ describe('POST /opinions', () => {
 			.send({ movieId: 550, hypeLevel: 4, comment: 'Hyped.' })
 
 		expect(response.status).toBe(201)
-		expect(Object.keys(response.body).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId'].sort())
+		expect(Object.keys(response.body).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId', 'netVoteCount', 'viewerVote'].sort())
 		expect(response.body).not.toHaveProperty('userId')
 		expect(response.body.author).toEqual({
 			username: 'critic7', honestyScore: 50, isLowTrust: false, isPhoneVerified: false
@@ -136,7 +136,7 @@ describe('GET /movies/:movieId/opinions', () => {
 		expect(response.body.results).toHaveLength(2)
 
 		for (const opinion of response.body.results) {
-			expect(Object.keys(opinion).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId'].sort())
+			expect(Object.keys(opinion).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId', 'netVoteCount', 'viewerVote'].sort())
 			expect(JSON.stringify(opinion)).not.toContain('@example.com')
 		}
 	})

--- a/server/actions/tests/reviews.test.ts
+++ b/server/actions/tests/reviews.test.ts
@@ -118,7 +118,7 @@ describe('POST /reviews', () => {
 		expect(Object.keys(response.body).sort()).toEqual(
 			[
 				'acting', 'author', 'cinematography', 'comment', 'createdAt', 'directing', 'editing', 'id', 'movieId',
-				'plot', 'score', 'writing'
+				'netVoteCount', 'plot', 'score', 'viewerVote', 'writing'
 			].sort()
 		)
 		expect(response.body).not.toHaveProperty('userId')

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -1,0 +1,405 @@
+import cookieParser from 'cookie-parser'
+import express from 'express'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import { HonestyLog } from '../../database/models/honesty-log'
+import { TrailerOpinion } from '../../database/models/trailer-opinion'
+import { User, UserDocument } from '../../database/models/User'
+import { Vote } from '../../database/models/vote'
+import movieRoutes from '../../routes/movie-routes'
+import opinionRoutes from '../../routes/opinion-routes'
+import reviewRoutes from '../../routes/review-routes'
+import voteRoutes from '../../routes/vote-routes'
+import { SESSION_COOKIE_NAME } from '../../session'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { createSignedSessionCookieValue } from '../../test-support/session'
+
+const app = express()
+
+app.use(express.json())
+app.use(cookieParser())
+app.use('/votes', voteRoutes())
+app.use('/opinions', opinionRoutes())
+app.use('/reviews', reviewRoutes())
+app.use('/movies', movieRoutes())
+
+async function seedUser(overrides: Partial<{ username: string; email: string; honestyScore: number }> = {}) {
+	return User.create({
+		username: overrides.username ?? 'critic7',
+		email: overrides.email ?? 'critic7@example.com',
+		honestyScore: overrides.honestyScore ?? 50
+	})
+}
+
+function sessionCookieFor(user: UserDocument) {
+	const value = createSignedSessionCookieValue({ userId: user.id, username: user.username })
+
+	return `${SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`
+}
+
+async function seedOpinion(authorId: string) {
+	return TrailerOpinion.create({ userId: authorId, movieId: 550, hypeLevel: 4, comment: '' })
+}
+
+async function waitForHonestyScore(
+	userId: string,
+	predicate: (score: number) => boolean,
+	timeoutMs = 2000
+): Promise<number> {
+	const start = Date.now()
+
+	while (Date.now() - start < timeoutMs) {
+		const user = await User.findById(userId).select('honestyScore')
+
+		if (user && predicate(user.honestyScore)) {
+			return user.honestyScore
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 10))
+	}
+
+	throw new Error('Timed out waiting for honesty score to update')
+}
+
+beforeAll(async() => {
+	await connectTestDatabase()
+	await Vote.init()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+describe('POST /votes', () => {
+	test('rejects a request with no session cookie', async() => {
+		const response = await request(app)
+			.post('/votes')
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011', voteValue: 1 })
+
+		expect(response.status).toBe(401)
+	})
+
+	test('rejects an invalid body', async() => {
+		const voter = await seedUser()
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'not-a-type', targetId: 'not-an-id', voteValue: 2 })
+
+		expect(response.status).toBe(400)
+	})
+
+	test('rejects a 404 for a target that does not exist', async() => {
+		const voter = await seedUser()
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011', voteValue: 1 })
+
+		expect(response.status).toBe(404)
+	})
+
+	test('blocks self-voting', async() => {
+		const author = await seedUser()
+		const opinion = await seedOpinion(author.id)
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(author))
+			.send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		expect(response.status).toBe(403)
+		expect(response.body).toEqual({
+			error: { code: 'SELF_VOTE_NOT_ALLOWED', message: 'You cannot vote on your own opinion or review.' }
+		})
+	})
+
+	test('ignores a body-supplied voterId — cannot vote as someone else by curling directly', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com' })
+		const impersonationTarget = await seedUser({ username: 'someone-else', email: 'else@example.com' })
+		const opinion = await seedOpinion(author.id)
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ voterId: impersonationTarget.id, targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		expect(response.status).toBe(201)
+
+		const stored = await Vote.findOne({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(stored?.voterId.toString()).toBe(voter.id)
+	})
+
+	test('one vote per user per target — a second vote changes the existing vote instead of creating a new one', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com' })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		const first = await request(app)
+			.post('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		expect(first.status).toBe(201)
+
+		const second = await request(app)
+			.post('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id, voteValue: -1 })
+
+		expect(second.status).toBe(200)
+		expect(second.body.voteValue).toBe(-1)
+
+		const votesForTarget = await Vote.find({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(votesForTarget).toHaveLength(1)
+		expect(votesForTarget[0].voteValue).toBe(-1)
+	})
+
+	test('resubmitting the same vote value is idempotent', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com' })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		expect(response.status).toBe(200)
+
+		const votesForTarget = await Vote.find({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(votesForTarget).toHaveLength(1)
+	})
+
+	test('rate limits after 100 votes in the last hour', async() => {
+		const voter = await seedUser()
+
+		await Vote.insertMany(
+			Array.from({ length: 100 }, () => ({
+				voterId: voter.id,
+				targetType: 'opinion',
+				targetId: new mongoose.Types.ObjectId(),
+				voteValue: 1,
+				voterWeightAtVote: 1
+			}))
+		)
+
+		const response = await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011', voteValue: 1 })
+
+		expect(response.status).toBe(429)
+	})
+})
+
+describe('voterWeightAtVote snapshot', () => {
+	test('a low-honesty-score voter contributes a smaller honesty-log delta than a high-score voter', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const lowScoreVoter = await seedUser({ username: 'low-score', email: 'low@example.com', honestyScore: 0 })
+		const highScoreVoter = await seedUser({ username: 'high-score', email: 'high@example.com', honestyScore: 100 })
+		const opinionForLowVoter = await seedOpinion(author.id)
+		const opinionForHighVoter = await TrailerOpinion.create({
+			userId: author.id, movieId: 551, hypeLevel: 3, comment: ''
+		})
+
+		await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(lowScoreVoter))
+			.send({ targetType: 'opinion', targetId: opinionForLowVoter.id, voteValue: 1 })
+
+		await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(highScoreVoter))
+			.send({ targetType: 'opinion', targetId: opinionForHighVoter.id, voteValue: 1 })
+
+		const lowVote = await Vote.findOne({ targetType: 'opinion', targetId: opinionForLowVoter.id })
+		const highVote = await Vote.findOne({ targetType: 'opinion', targetId: opinionForHighVoter.id })
+
+		// voteWeightFloor defaults to 0.2 (server/database/models/config.ts) —
+		// score 0 -> weight 0.2, score 100 -> weight 1.0.
+		expect(lowVote?.voterWeightAtVote).toBeCloseTo(0.2)
+		expect(highVote?.voterWeightAtVote).toBe(1)
+
+		const logs = await HonestyLog.find({ userId: author.id }).sort({ createdAt: 1 })
+
+		expect(logs).toHaveLength(2)
+		expect(logs[0].delta).toBeCloseTo(5) // 1 * 0.2 * 25
+		expect(logs[1].delta).toBeCloseTo(25) // 1 * 1.0 * 25
+		expect(Math.abs(logs[1].delta)).toBeGreaterThan(Math.abs(logs[0].delta))
+	})
+})
+
+describe('honesty score recalculation', () => {
+	test('triggers on vote create — target author score moves up', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com', honestyScore: 100 })
+		const opinion = await seedOpinion(author.id)
+
+		await request(app)
+			.post('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		const score = await waitForHonestyScore(author.id, current => current > 50)
+
+		expect(score).toBe(75)
+	})
+
+	test('triggers on vote change — target author score moves down after up becomes down', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com', honestyScore: 100 })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+		await waitForHonestyScore(author.id, current => current > 50)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: -1 })
+		const score = await waitForHonestyScore(author.id, current => current < 50)
+
+		expect(score).toBeLessThan(50)
+	})
+
+	test('triggers on vote delete — reverses the honesty-log contribution', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com', honestyScore: 100 })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+		await waitForHonestyScore(author.id, current => current > 50)
+
+		const deleteResponse = await request(app)
+			.delete('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(deleteResponse.status).toBe(204)
+
+		// The create (+25) and reversal (-25) entries land milliseconds apart,
+		// so their time-decay weights aren't bit-for-bit identical — the score
+		// settles very close to, but not always exactly, the 50 baseline.
+		const score = await waitForHonestyScore(author.id, current => Math.abs(current - 50) < 0.01)
+
+		expect(score).toBeCloseTo(50, 1)
+
+		const logs = await HonestyLog.find({ userId: author.id }).sort({ createdAt: 1 })
+
+		expect(logs).toHaveLength(2)
+		expect(logs[1].reason).toBe('upvote removed')
+		expect(logs[1].delta).toBeCloseTo(-25)
+	})
+})
+
+describe('DELETE /votes', () => {
+	test('rejects a request with no session cookie', async() => {
+		const response = await request(app)
+			.delete('/votes')
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011' })
+
+		expect(response.status).toBe(401)
+	})
+
+	test('returns 404 when there is no vote to remove', async() => {
+		const voter = await seedUser()
+
+		const response = await request(app)
+			.delete('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011' })
+
+		expect(response.status).toBe(404)
+	})
+
+	test('removes the vote', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com' })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		const response = await request(app)
+			.delete('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(response.status).toBe(204)
+		expect(await Vote.countDocuments({ targetType: 'opinion', targetId: opinion.id })).toBe(0)
+	})
+})
+
+describe('net vote count on opinion listings', () => {
+	test('GET /movies/:movieId/opinions reflects the sum of vote values', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const upvoterA = await seedUser({ username: 'up-a', email: 'up-a@example.com' })
+		const upvoterB = await seedUser({ username: 'up-b', email: 'up-b@example.com' })
+		const downvoter = await seedUser({ username: 'down', email: 'down@example.com' })
+		const opinion = await seedOpinion(author.id)
+
+		await request(app).post('/votes').set('Cookie', sessionCookieFor(upvoterA)).send({
+			targetType: 'opinion', targetId: opinion.id, voteValue: 1
+		})
+		await request(app).post('/votes').set('Cookie', sessionCookieFor(upvoterB)).send({
+			targetType: 'opinion', targetId: opinion.id, voteValue: 1
+		})
+		await request(app).post('/votes').set('Cookie', sessionCookieFor(downvoter)).send({
+			targetType: 'opinion', targetId: opinion.id, voteValue: -1
+		})
+
+		const response = await request(app).get('/movies/550/opinions')
+
+		expect(response.status).toBe(200)
+		expect(response.body.results).toHaveLength(1)
+		expect(response.body.results[0].netVoteCount).toBe(1) // +1 +1 -1
+	})
+
+	test('a freshly created opinion has netVoteCount 0', async() => {
+		const author = await seedUser()
+
+		const created = await request(app)
+			.post('/opinions')
+			.set('Cookie', sessionCookieFor(author))
+			.send({ movieId: 999, hypeLevel: 3, comment: '' })
+
+		expect(created.body.netVoteCount).toBe(0)
+	})
+
+	test('viewerVote reflects the requesting session\'s own vote, is null for a different or absent viewer', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const upvoter = await seedUser({ username: 'up', email: 'up@example.com' })
+		const bystander = await seedUser({ username: 'bystander', email: 'bystander@example.com' })
+		const opinion = await seedOpinion(author.id)
+
+		await request(app).post('/votes').set('Cookie', sessionCookieFor(upvoter)).send({
+			targetType: 'opinion', targetId: opinion.id, voteValue: 1
+		})
+
+		const asUpvoter = await request(app).get('/movies/550/opinions').set('Cookie', sessionCookieFor(upvoter))
+
+		expect(asUpvoter.body.results[0].viewerVote).toBe(1)
+
+		const asBystander = await request(app).get('/movies/550/opinions').set('Cookie', sessionCookieFor(bystander))
+
+		expect(asBystander.body.results[0].viewerVote).toBeNull()
+
+		const asGuest = await request(app).get('/movies/550/opinions')
+
+		expect(asGuest.body.results[0].viewerVote).toBeNull()
+	})
+})

--- a/server/actions/votes.ts
+++ b/server/actions/votes.ts
@@ -1,0 +1,189 @@
+import { NextFunction, Request, Response } from 'express'
+import mongoose from 'mongoose'
+import { HonestyLog } from '../database/models/honesty-log'
+import { Review } from '../database/models/review'
+import { TrailerOpinion } from '../database/models/trailer-opinion'
+import { User } from '../database/models/User'
+import { Vote, VoteDocument, VoteTargetType } from '../database/models/vote'
+import { getConfig } from '../lib/config'
+import { computeVoterWeight, enqueueHonestyScoreRecalculation } from '../lib/honesty-score'
+import { toVotePublicDTO } from '../serializers'
+import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
+
+// Precedent set by server/lib/tests/honesty-score-recalculation.test.ts
+// (`HonestyLog.create({ delta: 25, reason: 'received an upvote' })`): a
+// full-weight (honestyScore 100, weight 1.0) vote is worth 25 points on the
+// target author's log. Actual impact is scaled by the voter's weight and
+// moderated further by computeDecayedHonestyScore's weighted-average (not
+// sum) across a user's whole log, so no single vote — even a full-weight
+// one — can swing a score on its own the way this constant might suggest.
+const VOTE_HONESTY_DELTA_MAGNITUDE = 25
+
+const VOTE_RATE_LIMIT = 100
+const VOTE_RATE_WINDOW_MS = 60 * 60 * 1000
+
+const TARGET_MODELS: Record<VoteTargetType, typeof TrailerOpinion | typeof Review> = {
+	opinion: TrailerOpinion,
+	review: Review
+}
+
+const UNAUTHORIZED = {
+	error: { code: 'UNAUTHORIZED', message: 'Authentication required.' }
+}
+
+function isValidTargetType(value: unknown): value is VoteTargetType {
+	return value === 'opinion' || value === 'review'
+}
+
+function voteLabel(voteValue: 1 | -1): string {
+	return voteValue === 1 ? 'upvote' : 'downvote'
+}
+
+function voteReasonFor(voteValue: 1 | -1): string {
+	return `received a${voteValue === 1 ? 'n' : ''} ${voteLabel(voteValue)}`
+}
+
+async function isRateLimited(voterId: string): Promise<boolean> {
+	const count = await Vote.countDocuments({
+		voterId,
+		createdAt: { $gte: new Date(Date.now() - VOTE_RATE_WINDOW_MS) }
+	})
+
+	return count >= VOTE_RATE_LIMIT
+}
+
+// Same trust boundary as server/actions/opinions.ts and reviews.ts:
+// identity comes from the signed `__session` cookie, never a request body
+// field — Express is directly reachable over the network.
+export const castVote = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const voterId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
+
+		if (!voterId) {
+			response.status(401).json(UNAUTHORIZED)
+			return
+		}
+
+		const { targetType, targetId, voteValue } = request.body as {
+			targetType?: unknown
+			targetId?: unknown
+			voteValue?: unknown
+		}
+
+		if (!isValidTargetType(targetType) || typeof targetId !== 'string' || !mongoose.isValidObjectId(targetId) ||
+			(voteValue !== 1 && voteValue !== -1)) {
+			response.status(400).json({
+				error: { code: 'INVALID_VOTE', message: 'targetType, targetId, and voteValue (1 or -1) are required' }
+			})
+			return
+		}
+
+		if (await isRateLimited(voterId)) {
+			response.status(429).json({
+				error: { code: 'RATE_LIMITED', message: 'Too many votes — try again later.' }
+			})
+			return
+		}
+
+		const target = await TARGET_MODELS[targetType].findById(targetId).select('userId')
+
+		if (!target) {
+			response.status(404).json({ error: { code: 'NOT_FOUND', message: 'Vote target not found.' } })
+			return
+		}
+
+		if (target.userId.toString() === voterId) {
+			response.status(403).json({
+				error: { code: 'SELF_VOTE_NOT_ALLOWED', message: 'You cannot vote on your own opinion or review.' }
+			})
+			return
+		}
+
+		const [voter, config, existingVote] = await Promise.all([
+			User.findById(voterId).select('honestyScore'),
+			getConfig(),
+			Vote.findOne({ voterId, targetType, targetId })
+		])
+
+		if (!voter) {
+			response.status(401).json(UNAUTHORIZED)
+			return
+		}
+
+		const previousVoteValue = existingVote?.voteValue ?? null
+
+		if (previousVoteValue === voteValue) {
+			// Idempotent resubmission of the same vote — no state change, no
+			// honesty-log churn, just echo back the existing vote.
+			response.status(200).json(toVotePublicDTO(existingVote as VoteDocument))
+			return
+		}
+
+		const voterWeightAtVote = computeVoterWeight(voter.honestyScore, config.voteWeightFloor)
+
+		const vote = await Vote.findOneAndUpdate(
+			{ voterId, targetType, targetId },
+			{ voteValue, voterWeightAtVote, createdAt: new Date() },
+			{ upsert: true, new: true, setDefaultsOnInsert: true }
+		)
+
+		const delta = previousVoteValue === null
+			? voteValue * voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
+			: (voteValue - previousVoteValue) * voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
+		const reason = previousVoteValue === null
+			? voteReasonFor(voteValue)
+			: `vote changed from ${voteLabel(previousVoteValue)} to ${voteLabel(voteValue)}`
+
+		await HonestyLog.create({ userId: target.userId, delta, reason })
+		enqueueHonestyScoreRecalculation(target.userId.toString())
+
+		response.status(previousVoteValue === null ? 201 : 200).json(toVotePublicDTO(vote as VoteDocument))
+	} catch (error) {
+		next(error)
+	}
+}
+
+export const removeVote = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const voterId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
+
+		if (!voterId) {
+			response.status(401).json(UNAUTHORIZED)
+			return
+		}
+
+		const { targetType, targetId } = request.body as { targetType?: unknown; targetId?: unknown }
+
+		if (!isValidTargetType(targetType) || typeof targetId !== 'string' || !mongoose.isValidObjectId(targetId)) {
+			response.status(400).json({
+				error: { code: 'INVALID_VOTE', message: 'targetType and targetId are required' }
+			})
+			return
+		}
+
+		const deletedVote = await Vote.findOneAndDelete({ voterId, targetType, targetId })
+
+		if (!deletedVote) {
+			response.status(404).json({ error: { code: 'NOT_FOUND', message: 'Vote not found.' } })
+			return
+		}
+
+		const vote = deletedVote as unknown as VoteDocument
+		const target = await TARGET_MODELS[vote.targetType].findById(vote.targetId).select('userId')
+
+		// The target itself may have been deleted since the vote was cast —
+		// nothing to attribute the reversal to in that case, so the vote
+		// removal still succeeds, it just has no honesty-log side effect.
+		if (target) {
+			const delta = -vote.voteValue * vote.voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
+			const reason = `${voteLabel(vote.voteValue)} removed`
+
+			await HonestyLog.create({ userId: target.userId, delta, reason })
+			enqueueHonestyScoreRecalculation(target.userId.toString())
+		}
+
+		response.status(204).send()
+	} catch (error) {
+		next(error)
+	}
+}

--- a/server/database/models/vote.ts
+++ b/server/database/models/vote.ts
@@ -26,4 +26,9 @@ const voteSchema = new Schema<VoteDocument>({
 // Enforces one vote per user per target at the database level, not just app logic.
 voteSchema.index({ voterId: 1, targetType: 1, targetId: 1 }, { unique: true })
 
+// Matches the per-voter rate-limit window query in server/actions/votes.ts
+// (count a voter's votes in the last hour) — the unique index above only
+// has voterId as a usable prefix for that query, not createdAt.
+voteSchema.index({ voterId: 1, createdAt: 1 })
+
 export const Vote = mongoose.models.Vote || mongoose.model<VoteDocument>('Vote', voteSchema)

--- a/server/lib/vote-counts.ts
+++ b/server/lib/vote-counts.ts
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose'
+import { Vote, VoteTargetType } from '../database/models/vote'
+
+export interface VoteSummary {
+	netVoteCount: number
+	// The requesting viewer's own vote on this target, so the client knows
+	// which button to render active (and can toggle it off via DELETE
+	// /votes rather than re-submitting the same value) — null both when the
+	// viewer hasn't voted and when there is no authenticated viewer at all.
+	viewerVote: 1 | -1 | null
+}
+
+// Keyed by targetId string so callers can look up a summary per item
+// without caring about ObjectId identity comparisons.
+export async function getVoteSummaries(
+	targetType: VoteTargetType,
+	targetIds: mongoose.Types.ObjectId[],
+	viewerId: string | null
+): Promise<Map<string, VoteSummary>> {
+	if (targetIds.length === 0) {
+		return new Map()
+	}
+
+	const [netVoteResults, viewerVotes] = await Promise.all([
+		Vote.aggregate<{ _id: mongoose.Types.ObjectId; netVoteCount: number }>([
+			{ $match: { targetType, targetId: { $in: targetIds } } },
+			{ $group: { _id: '$targetId', netVoteCount: { $sum: '$voteValue' } } }
+		]),
+		viewerId
+			? Vote.find({ voterId: viewerId, targetType, targetId: { $in: targetIds } }).select('targetId voteValue')
+			: Promise.resolve([])
+	])
+
+	const netVoteCountByTargetId = new Map(netVoteResults.map(result => [result._id.toString(), result.netVoteCount]))
+	const viewerVoteByTargetId = new Map(viewerVotes.map(vote => [vote.targetId.toString(), vote.voteValue]))
+
+	const targetIdStrings = new Set([
+		...netVoteCountByTargetId.keys(),
+		...targetIds.map(targetId => targetId.toString())
+	])
+
+	return new Map(
+		Array.from(targetIdStrings, targetIdString => [
+			targetIdString,
+			{
+				netVoteCount: netVoteCountByTargetId.get(targetIdString) ?? 0,
+				viewerVote: viewerVoteByTargetId.get(targetIdString) ?? null
+			}
+		])
+	)
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import authRoutes from './auth-routes'
 import movieRoutes from './movie-routes'
 import opinionRoutes from './opinion-routes'
 import reviewRoutes from './review-routes'
+import voteRoutes from './vote-routes'
 
 const router = express.Router()
 
@@ -11,6 +12,7 @@ router.use('/movies', movieRoutes())
 router.use('/auth', authRoutes())
 router.use('/opinions', opinionRoutes())
 router.use('/reviews', reviewRoutes())
+router.use('/votes', voteRoutes())
 router.get('/', getPopular)
 
 export default router

--- a/server/routes/vote-routes.ts
+++ b/server/routes/vote-routes.ts
@@ -1,0 +1,13 @@
+import express from 'express'
+import { castVote, removeVote } from '../actions'
+
+const voteRoutes = () => {
+	const router = express.Router()
+
+	router.post('/', castVote)
+	router.delete('/', removeVote)
+
+	return router
+}
+
+export default voteRoutes

--- a/server/serializers/review.ts
+++ b/server/serializers/review.ts
@@ -1,5 +1,6 @@
 import { ReviewDocument } from '../database/models/review'
 import { UserDocument } from '../database/models/User'
+import { VoteSummary } from '../lib/vote-counts'
 import { toUserPublicDTO, UserPublicDTO } from './users'
 
 export interface ReviewPublicDTO {
@@ -14,6 +15,8 @@ export interface ReviewPublicDTO {
 	editing: number
 	cinematography: number
 	comment: string
+	netVoteCount: number
+	viewerVote: 1 | -1 | null
 	createdAt: Date
 }
 
@@ -25,6 +28,7 @@ export type PopulatedReviewDocument = Omit<ReviewDocument, 'userId'> & { userId:
 
 export function toReviewPublicDTO(
 	review: PopulatedReviewDocument,
+	voteSummary: VoteSummary,
 	lowTrustBadgeThreshold?: number
 ): ReviewPublicDTO {
 	return {
@@ -39,6 +43,8 @@ export function toReviewPublicDTO(
 		editing: review.editing,
 		cinematography: review.cinematography,
 		comment: review.comment,
+		netVoteCount: voteSummary.netVoteCount,
+		viewerVote: voteSummary.viewerVote,
 		createdAt: review.createdAt
 	}
 }

--- a/server/serializers/tests/review.test.ts
+++ b/server/serializers/tests/review.test.ts
@@ -25,14 +25,16 @@ const review = {
 
 describe('review serializer allowlist', () => {
 	test('public DTO exposes author as UserPublicDTO, never raw userId or email', () => {
-		const dto = toReviewPublicDTO(review as never)
+		const dto = toReviewPublicDTO(review as never, { netVoteCount: 3, viewerVote: 1 })
 
 		expect(Object.keys(dto).sort()).toEqual(
 			[
 				'acting', 'author', 'cinematography', 'comment', 'createdAt', 'directing', 'editing', 'id', 'movieId',
-				'plot', 'score', 'writing'
+				'netVoteCount', 'plot', 'score', 'viewerVote', 'writing'
 			].sort()
 		)
+		expect(dto.netVoteCount).toBe(3)
+		expect(dto.viewerVote).toBe(1)
 		expect(dto).not.toHaveProperty('userId')
 		expect(dto.author).toEqual({
 			username: 'critic7',
@@ -45,6 +47,6 @@ describe('review serializer allowlist', () => {
 	test('author.isLowTrust reflects the low-trust threshold', () => {
 		const lowTrustReview = { ...review, userId: { ...user, honestyScore: 10 } }
 
-		expect(toReviewPublicDTO(lowTrustReview as never).author.isLowTrust).toBe(true)
+		expect(toReviewPublicDTO(lowTrustReview as never, { netVoteCount: 0, viewerVote: null }).author.isLowTrust).toBe(true)
 	})
 })

--- a/server/serializers/tests/trailer-opinion.test.ts
+++ b/server/serializers/tests/trailer-opinion.test.ts
@@ -19,9 +19,13 @@ const opinion = {
 
 describe('trailer opinion serializer allowlist', () => {
 	test('public DTO exposes author as UserPublicDTO, never raw userId or email', () => {
-		const dto = toTrailerOpinionPublicDTO(opinion as never)
+		const dto = toTrailerOpinionPublicDTO(opinion as never, { netVoteCount: 3, viewerVote: -1 })
 
-		expect(Object.keys(dto).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId'].sort())
+		expect(Object.keys(dto).sort()).toEqual(
+			['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId', 'netVoteCount', 'viewerVote'].sort()
+		)
+		expect(dto.netVoteCount).toBe(3)
+		expect(dto.viewerVote).toBe(-1)
 		expect(dto).not.toHaveProperty('userId')
 		expect(dto.author).toEqual({
 			username: 'critic7',
@@ -34,6 +38,8 @@ describe('trailer opinion serializer allowlist', () => {
 	test('author.isLowTrust reflects the low-trust threshold', () => {
 		const lowTrustOpinion = { ...opinion, userId: { ...user, honestyScore: 10 } }
 
-		expect(toTrailerOpinionPublicDTO(lowTrustOpinion as never).author.isLowTrust).toBe(true)
+		expect(
+			toTrailerOpinionPublicDTO(lowTrustOpinion as never, { netVoteCount: 0, viewerVote: null }).author.isLowTrust
+		).toBe(true)
 	})
 })

--- a/server/serializers/trailer-opinion.ts
+++ b/server/serializers/trailer-opinion.ts
@@ -1,5 +1,6 @@
 import { TrailerOpinionDocument } from '../database/models/trailer-opinion'
 import { UserDocument } from '../database/models/User'
+import { VoteSummary } from '../lib/vote-counts'
 import { toUserPublicDTO, UserPublicDTO } from './users'
 
 export interface TrailerOpinionPublicDTO {
@@ -8,6 +9,8 @@ export interface TrailerOpinionPublicDTO {
 	author: UserPublicDTO
 	hypeLevel: number
 	comment: string
+	netVoteCount: number
+	viewerVote: 1 | -1 | null
 	createdAt: Date
 }
 
@@ -18,6 +21,7 @@ export type PopulatedTrailerOpinionDocument = Omit<TrailerOpinionDocument, 'user
 
 export function toTrailerOpinionPublicDTO(
 	opinion: PopulatedTrailerOpinionDocument,
+	voteSummary: VoteSummary,
 	lowTrustBadgeThreshold?: number
 ): TrailerOpinionPublicDTO {
 	return {
@@ -26,6 +30,8 @@ export function toTrailerOpinionPublicDTO(
 		author: toUserPublicDTO(opinion.userId, lowTrustBadgeThreshold),
 		hypeLevel: opinion.hypeLevel,
 		comment: opinion.comment,
+		netVoteCount: voteSummary.netVoteCount,
+		viewerVote: voteSummary.viewerVote,
 		createdAt: opinion.createdAt
 	}
 }


### PR DESCRIPTION
## Look here first: voterWeightAtVote snapshot + async recalc

Every vote records `voterWeightAtVote` — the voter's honesty-score-derived weight (`computeVoterWeight`, linear scale from `voteWeightFloor` to 1.0) **at the moment the vote is cast**, not recomputed later. This is deliberate: a voter's score changing afterward must not retroactively reweight votes they already cast — otherwise the recalculation job would be non-deterministic and un-auditable (a user's later behavior could silently alter history). This snapshot behavior was already decided in Phase 2 (see the comment on `VoteDocument.voterWeightAtVote`); this PR is the first code that actually reads it.

Each vote create/change/delete writes a `HonestyLog` entry for the **target's author** — `delta = voteValue * voterWeightAtVote * 25` (25 taken from the existing precedent in `server/lib/tests/honesty-score-recalculation.test.ts`: `HonestyLog.create({ delta: 25, reason: 'received an upvote' })`, i.e. a full-weight vote is worth 25 raw points before Phase 2's time-decayed weighted-average moderates it). A **vote change** logs the net swing (`(newValue - oldValue) * weight * 25`) as one entry rather than mutating the original — HonestyLog is an append-only audit ledger, consistent with its existing "abuse review" purpose. A **vote removal** logs the reversal. None of this blocks the request/response cycle: `enqueueHonestyScoreRecalculation` is fire-and-forget (existing Phase 2 pattern), so a slow or failing recalculation never delays the vote itself.

Reviewer, please check specifically: the delta-on-change math (`server/actions/votes.ts`, `castVote`), and that the fire-and-forget recalc is correctly triggered on all three paths (create/change/delete) — tests wait on it via polling since it's genuinely async (see `waitForHonestyScore` in `server/actions/tests/votes.test.ts`).

## What else is in here

**Server**
- `POST /votes`, `DELETE /votes` — same Express-side session verification as phase5/2 (PR #76): identity comes from the signed `__session` cookie, a body-supplied `voterId` is ignored entirely. Verified with an impersonation-attempt test (cookie's real owner casts the vote regardless of what the body claims).
- One vote per user per target — the Phase 2 unique index on `(voterId, targetType, targetId)` is now exercised: a second vote on the same target *changes* the existing vote (upsert) rather than erroring; resubmitting the identical value is a no-op (no honesty-log churn).
- Self-voting blocked (403) — checked against the target's actual author before anything else happens.
- Rate limit: 100 votes/hour per voter, checked against `Vote`'s own `createdAt` (a dedicated `(voterId, createdAt)` index backs this — the existing unique index only has `voterId` as a usable prefix for a range query).
- `GET /movies/:movieId/opinions` and `/reviews` now also return `netVoteCount` (sum of vote values) and `viewerVote` (the requesting session's own vote on that item, `null` if unauthenticated or not voted) per item — computed via a single aggregation per page load, not N+1 queries.

**Client**
- `ui/vote-buttons.tsx` — up/down buttons, submits through the route's `action` via `useFetcher` (JS-driven by design here, unlike the no-JS opinion/review forms), optimistic count update computed from the in-flight fetcher submission.
- Toggle-remove: tapping the already-active direction submits `DELETE /votes` instead of re-POSTing — needed `viewerVote` threaded from the loader through to know which button is currently active, plus active-state styling (filled + colored vs. subtle/gray).
- Own cards render no vote buttons at all (self-vote is blocked server-side anyway; showing a control that always 403s is worse than not showing one).
- Logged-out: counts still render, clicking either button navigates to `/login` instead of submitting.
- Honesty score now renders on the author line next to the existing low-trust badge on every opinion/review card.

**Known scope cut:** votes.ts's `castVote` doesn't independently re-derive whether a HonestyLog write should also account for the target having been deleted mid-request — if the target opinion/review is deleted between the vote's own existence check and a later `removeVote` call, the deletion path already handles a missing target by skipping the honesty-log side effect silently (see the comment in `removeVote`); this isn't expected to happen in normal use (no delete-review/opinion endpoint exists yet) and isn't otherwise tested.

## Test plan
- [x] `pnpm exec tsc --noEmit` (server) and `pnpm typecheck` (client) — both clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 19 suites, 106 tests, all passing, including: one-vote-per-target + vote-change path, self-vote rejection, voterWeightAtVote snapshot correctness (a 0-honesty-score voter's vote logs 5 points vs. a 100-score voter's 25), impersonation attempt, honesty-score recalculation triggering on create/change/delete (polled, since it's fire-and-forget), rate limiting, `viewerVote` correctness (own vote vs. a different viewer vs. no session)
- [ ] Full page smoke test (buttons rendering/toggling in an actual browser) pending a local run — this environment has no TMDB `API_KEY` for the movie-detail loader's other calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upvote and downvote controls for movie opinions and reviews.
  * Vote totals and your current vote are now displayed with each item.
  * Voting updates the interface immediately and supports changing or removing votes.
  * Unauthenticated visitors are prompted to sign in before voting.
* **Bug Fixes**
  * Voting controls are hidden on your own opinions and reviews.
  * Added validation and safeguards to prevent duplicate or invalid votes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->