### PR TITLE
phase5.5: full audit fixes — vote/honesty-score correctness, security, performance

### DIFF
--- a/client/src/routes/movies.$movieId.tsx
+++ b/client/src/routes/movies.$movieId.tsx
@@ -37,11 +37,17 @@ export function meta({ loaderData }: Route.MetaArgs) {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs): Promise<MovieDetailLoaderData> {
+	// Forwarded the same way the mutation actions below already do — without
+	// it, Express never sees the viewer's session on these GET requests, so
+	// viewerVote comes back null even for a logged-in viewer who has voted
+	// (the vote buttons would never render as active).
+	const cookie = request.headers.get('Cookie') ?? ''
+
 	const [movieResponse, videosResponse, opinionsResponse, reviewsResponse, session] = await Promise.all([
 		fetch(`${API_URL}/movies/details?movieId=${params.movieId}`),
 		fetch(`${API_URL}/movies/videos?movieId=${params.movieId}`),
-		fetch(`${API_URL}/movies/${params.movieId}/opinions`),
-		fetch(`${API_URL}/movies/${params.movieId}/reviews`),
+		fetch(`${API_URL}/movies/${params.movieId}/opinions`, { headers: { Cookie: cookie } }),
+		fetch(`${API_URL}/movies/${params.movieId}/reviews`, { headers: { Cookie: cookie } }),
 		getSession(request)
 	])
 

--- a/client/src/ui/vote-buttons.tsx
+++ b/client/src/ui/vote-buttons.tsx
@@ -61,6 +61,7 @@ export default function VoteButtons({ targetType, targetId, netVoteCount, viewer
         color={optimisticViewerVote === 1 ? 'orange' : 'gray'}
         aria-label="Upvote"
         aria-pressed={optimisticViewerVote === 1}
+        disabled={isPendingForThisTarget}
         onClick={() => vote(1)}
       >
         ▲
@@ -73,6 +74,7 @@ export default function VoteButtons({ targetType, targetId, netVoteCount, viewer
         color={optimisticViewerVote === -1 ? 'blue' : 'gray'}
         aria-label="Downvote"
         aria-pressed={optimisticViewerVote === -1}
+        disabled={isPendingForThisTarget}
         onClick={() => vote(-1)}
       >
         ▼

--- a/server/actions/movies.ts
+++ b/server/actions/movies.ts
@@ -6,6 +6,20 @@ import {TmdbMovie} from '../tmdb-wrapper'
 
 const Tmdb = new TmdbMovie(process.env.API_KEY)
 
+// TMDB ids are always positive integers. request.query.movieId is otherwise
+// unknown-shaped (Express parses repeated query keys as an array, and an
+// absent key as undefined) — String(request.query.movieId) on either of
+// those produces a value like "undefined" or "1,2" that gets interpolated
+// straight into the upstream URL (server/tmdb-wrapper/movie-db-wrapper.ts)
+// with no validation at all.
+function parseMovieId(value: unknown): string | null {
+	return typeof value === 'string' && /^\d+$/.test(value) ? value : null
+}
+
+const INVALID_MOVIE_ID = {
+	error: { code: 'INVALID_MOVIE_ID', message: 'movieId must be a numeric TMDB id' }
+}
+
 export const getPopular = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const popularMovies = await Tmdb.getPopularMovies()
@@ -38,7 +52,14 @@ export const getUpcoming = async(request: Request, response: Response, next: Nex
 
 export const getDetails = async(request: Request, response: Response, next: NextFunction) => {
 	try {
-		const movieDetails = await Tmdb.getMovieDetails(String(request.query.movieId))
+		const movieId = parseMovieId(request.query.movieId)
+
+		if (!movieId) {
+			response.status(400).json(INVALID_MOVIE_ID)
+			return
+		}
+
+		const movieDetails = await Tmdb.getMovieDetails(movieId)
 
 		response.send(await toMovieDetailsDTO(movieDetails))
 	} catch (error) {
@@ -48,7 +69,14 @@ export const getDetails = async(request: Request, response: Response, next: Next
 
 export const getCredits = async(request: Request, response: Response, next: NextFunction) => {
 	try {
-		const movieCredits = await Tmdb.getMovieCredits(String(request.query.movieId))
+		const movieId = parseMovieId(request.query.movieId)
+
+		if (!movieId) {
+			response.status(400).json(INVALID_MOVIE_ID)
+			return
+		}
+
+		const movieCredits = await Tmdb.getMovieCredits(movieId)
 
 		response.send(toMovieCreditsDTO(movieCredits))
 	} catch (error) {
@@ -68,7 +96,14 @@ export const getNowPlaying = async(request: Request, response: Response, next: N
 
 export const getImages = async(request: Request, response: Response, next: NextFunction) => {
 	try {
-		const movieImages = await Tmdb.getMovieImages(String(request.query.movieId))
+		const movieId = parseMovieId(request.query.movieId)
+
+		if (!movieId) {
+			response.status(400).json(INVALID_MOVIE_ID)
+			return
+		}
+
+		const movieImages = await Tmdb.getMovieImages(movieId)
 
 		response.send(toMovieImagesDTO(movieImages))
 	} catch (error) {
@@ -78,7 +113,14 @@ export const getImages = async(request: Request, response: Response, next: NextF
 
 export const getVideos = async(request: Request, response: Response, next: NextFunction) => {
 	try {
-		const movieVideos = await Tmdb.getMovieVideos(String(request.query.movieId))
+		const movieId = parseMovieId(request.query.movieId)
+
+		if (!movieId) {
+			response.status(400).json(INVALID_MOVIE_ID)
+			return
+		}
+
+		const movieVideos = await Tmdb.getMovieVideos(movieId)
 
 		response.send(toMovieVideosDTO(movieVideos))
 	} catch (error) {

--- a/server/actions/opinions.ts
+++ b/server/actions/opinions.ts
@@ -74,6 +74,13 @@ export const createOpinion = async(request: Request, response: Response, next: N
 	}
 }
 
+// DEFERRED (audit #9, documented not built — no caching layer exists yet):
+// this response includes viewerVote, personalized per requesting session
+// via the Cookie header. No cross-user leak today (see getVoteSummaries),
+// but if a shared cache (CDN, reverse proxy) is ever placed in front of
+// Express without being cookie-aware, one viewer's personalized response
+// could be served to another. Anyone adding caching here must key on the
+// session, not just the URL.
 export const getMovieOpinions = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const movieId = Number(request.params.movieId)

--- a/server/actions/reviews.ts
+++ b/server/actions/reviews.ts
@@ -100,6 +100,10 @@ export const createReview = async(request: Request, response: Response, next: Ne
 	}
 }
 
+// DEFERRED (audit #9, documented not built — no caching layer exists yet):
+// same personalization note as server/actions/opinions.ts's getMovieOpinions
+// — this response's viewerVote is cookie-personalized, so any future
+// shared cache in front of Express must be cookie-aware.
 export const getMovieReviews = async(request: Request, response: Response, next: NextFunction) => {
 	try {
 		const movieId = Number(request.params.movieId)

--- a/server/actions/tests/movies.test.ts
+++ b/server/actions/tests/movies.test.ts
@@ -1,0 +1,68 @@
+import axios from 'axios'
+import express from 'express'
+import request from 'supertest'
+import { getCredits, getDetails, getImages, getVideos } from '../movies'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const app = express()
+
+app.get('/movies/details', getDetails)
+app.get('/movies/credits', getCredits)
+app.get('/movies/images', getImages)
+app.get('/movies/videos', getVideos)
+
+const ROUTES = ['/movies/details', '/movies/credits', '/movies/images', '/movies/videos']
+
+beforeEach(() => {
+	mockedAxios.get.mockResolvedValue({ data: { id: 550 } })
+})
+
+afterEach(() => {
+	jest.clearAllMocks()
+})
+
+// TMDB ids are always positive integers, but request.query.movieId is
+// otherwise unvalidated (Express parses a missing key as undefined and a
+// repeated key as an array) before being stringified straight into the
+// upstream URL — see server/tmdb-wrapper/movie-db-wrapper.ts.
+describe('movieId validation on TMDB-proxy routes', () => {
+	test.each(ROUTES)('%s rejects a missing movieId', async(path) => {
+		const response = await request(app).get(path)
+
+		expect(response.status).toBe(400)
+		expect(mockedAxios.get).not.toHaveBeenCalled()
+	})
+
+	test.each(ROUTES)('%s rejects a non-numeric movieId', async(path) => {
+		const response = await request(app).get(path).query({ movieId: '550/../secret' })
+
+		expect(response.status).toBe(400)
+		expect(mockedAxios.get).not.toHaveBeenCalled()
+	})
+
+	test.each(ROUTES)('%s rejects a repeated movieId query key (parsed as an array)', async(path) => {
+		const response = await request(app).get(`${path}?movieId=1&movieId=2`)
+
+		expect(response.status).toBe(400)
+		expect(mockedAxios.get).not.toHaveBeenCalled()
+	})
+
+	test.each(ROUTES)('%s accepts a valid numeric movieId and passes it straight through', async(path) => {
+		const response = await request(app).get(path).query({ movieId: '550' })
+
+		expect(response.status).toBe(200)
+		expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('/550'))
+	})
+
+	test('a movieId containing a path segment cannot inject an extra URL segment', async() => {
+		await request(app).get('/movies/details').query({ movieId: '550' })
+
+		const [calledUrl] = mockedAxios.get.mock.calls[0]
+
+		expect(calledUrl).toContain('/movie/550?')
+		expect(calledUrl).not.toContain('..')
+	})
+})

--- a/server/actions/tests/votes-property.test.ts
+++ b/server/actions/tests/votes-property.test.ts
@@ -1,0 +1,188 @@
+import cookieParser from 'cookie-parser'
+import express from 'express'
+import request from 'supertest'
+import { DEFAULT_VOTE_WEIGHT_FLOOR } from '../../database/models/config'
+import { HonestyLog } from '../../database/models/honesty-log'
+import { TrailerOpinion } from '../../database/models/trailer-opinion'
+import { User, UserDocument } from '../../database/models/User'
+import { computeVoterWeight } from '../../lib/honesty-score'
+import opinionRoutes from '../../routes/opinion-routes'
+import voteRoutes from '../../routes/vote-routes'
+import { SESSION_COOKIE_NAME } from '../../session'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { createSignedSessionCookieValue } from '../../test-support/session'
+
+const app = express()
+
+app.use(express.json())
+app.use(cookieParser())
+app.use('/votes', voteRoutes())
+app.use('/opinions', opinionRoutes())
+
+const VOTE_HONESTY_DELTA_MAGNITUDE = 25
+
+// Fixed, varied honesty scores rather than a single shared one — a
+// meaningful property check needs voters whose weights actually differ, so
+// a bug that only shows up when weights vary (or when a voter's weight
+// must stay pinned across several operations) can't hide behind a
+// coincidental cancellation.
+const VOTER_HONESTY_SCORES = [100, 55, 0]
+
+interface Operation {
+	voterIndex: number
+	action: 'vote' | 'delete'
+	value?: 1 | -1
+}
+
+function sessionCookieFor(user: UserDocument) {
+	const value = createSignedSessionCookieValue({ userId: user.id, username: user.username })
+
+	return `${SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`
+}
+
+async function waitForLogCount(userId: string, expected: number, timeoutMs = 2000): Promise<void> {
+	const start = Date.now()
+
+	while (Date.now() - start < timeoutMs) {
+		const count = await HonestyLog.countDocuments({ userId })
+
+		if (count === expected) {
+			return
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 10))
+	}
+
+	throw new Error(`Timed out waiting for HonestyLog count to reach ${expected}`)
+}
+
+async function runSequence(operations: Operation[]) {
+	const author = await User.create({ username: 'author', email: 'author@example.com', honestyScore: 50 })
+	const voters = await Promise.all(
+		VOTER_HONESTY_SCORES.map((honestyScore, index) =>
+			User.create({ username: `voter${index}`, email: `voter${index}@example.com`, honestyScore }))
+	)
+	const opinion = await TrailerOpinion.create({ userId: author.id, movieId: 550, hypeLevel: 4, comment: '' })
+
+	// Tracks, per voter, the weight pinned at their FIRST cast (FIX 5: a
+	// change must reuse it, never recompute) and their current final vote
+	// value (undefined once deleted).
+	const originalWeightByVoter = new Map<number, number>()
+	const finalValueByVoter = new Map<number, 1 | -1>()
+
+	for (const operation of operations) {
+		const voter = voters[operation.voterIndex]
+		const cookie = sessionCookieFor(voter)
+
+		if (!originalWeightByVoter.has(operation.voterIndex)) {
+			originalWeightByVoter.set(
+				operation.voterIndex,
+				computeVoterWeight(VOTER_HONESTY_SCORES[operation.voterIndex], DEFAULT_VOTE_WEIGHT_FLOOR)
+			)
+		}
+
+		if (operation.action === 'vote') {
+			await request(app).post('/votes').set('Cookie', cookie).send({
+				targetType: 'opinion', targetId: opinion.id, voteValue: operation.value
+			})
+			finalValueByVoter.set(operation.voterIndex, operation.value as 1 | -1)
+		} else {
+			await request(app).delete('/votes').set('Cookie', cookie).send({
+				targetType: 'opinion', targetId: opinion.id
+			})
+			finalValueByVoter.delete(operation.voterIndex)
+		}
+	}
+
+	const expectedEntries = Array.from(finalValueByVoter.entries())
+		.map(([voterIndex, finalValue]) => {
+			const weight = originalWeightByVoter.get(voterIndex) as number
+
+			return { delta: finalValue * weight * VOTE_HONESTY_DELTA_MAGNITUDE }
+		})
+		.sort((a, b) => a.delta - b.delta)
+
+	await waitForLogCount(author.id, expectedEntries.length)
+
+	const actualEntries = (await HonestyLog.find({ userId: author.id }).select('delta').lean())
+		.map(entry => ({ delta: entry.delta }))
+		.sort((a, b) => a.delta - b.delta)
+
+	return { expectedEntries, actualEntries }
+}
+
+beforeAll(async() => {
+	await connectTestDatabase()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+/*
+ * Property under test: for any sequence of vote/change/delete operations by
+ * N voters against one target, HonestyLog must always contain exactly one
+ * entry per voter with a currently-active vote, with a delta computed from
+ * that voter's ORIGINAL cast-time weight and their FINAL vote value —
+ * identical to what a from-scratch vote of that same final state would
+ * produce. This is the exact property the audit's delta-on-change bug
+ * (incremental swings appended on top of a stale entry) violated, and
+ * would have caught it: the pre-fix code left extra/stale entries behind
+ * whenever a vote changed more than once.
+ */
+describe.each<[string, Operation[]]>([
+	[
+		'repeated changes by a single voter (up, down, up)',
+		[
+			{ voterIndex: 0, action: 'vote', value: 1 },
+			{ voterIndex: 0, action: 'vote', value: -1 },
+			{ voterIndex: 0, action: 'vote', value: 1 }
+		]
+	],
+	[
+		'two voters interleaved, one changes their mind, one deletes and revotes',
+		[
+			{ voterIndex: 0, action: 'vote', value: 1 },
+			{ voterIndex: 1, action: 'vote', value: 1 },
+			{ voterIndex: 0, action: 'vote', value: -1 },
+			{ voterIndex: 1, action: 'delete' },
+			{ voterIndex: 1, action: 'vote', value: -1 }
+		]
+	],
+	[
+		'a single voter fully cycles (vote, delete, vote, change, delete) — ends with no vote at all',
+		[
+			{ voterIndex: 0, action: 'vote', value: 1 },
+			{ voterIndex: 0, action: 'delete' },
+			{ voterIndex: 0, action: 'vote', value: -1 },
+			{ voterIndex: 0, action: 'vote', value: 1 },
+			{ voterIndex: 0, action: 'delete' }
+		]
+	],
+	[
+		'three voters with different weights, mixed changes and one deletion',
+		[
+			{ voterIndex: 0, action: 'vote', value: 1 },
+			{ voterIndex: 1, action: 'vote', value: -1 },
+			{ voterIndex: 2, action: 'vote', value: 1 },
+			{ voterIndex: 0, action: 'vote', value: -1 },
+			{ voterIndex: 1, action: 'vote', value: 1 },
+			{ voterIndex: 2, action: 'delete' },
+			{ voterIndex: 0, action: 'delete' }
+		]
+	]
+])('delta-on-change property: %s', (_description, operations) => {
+	test('HonestyLog exactly matches a from-scratch vote of the final state', async() => {
+		const { expectedEntries, actualEntries } = await runSequence(operations)
+
+		expect(actualEntries).toHaveLength(expectedEntries.length)
+
+		for (let index = 0; index < expectedEntries.length; index++) {
+			expect(actualEntries[index].delta).toBeCloseTo(expectedEntries[index].delta, 6)
+		}
+	})
+})

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -289,6 +289,39 @@ describe('voterWeightAtVote snapshot', () => {
 		expect(logs[1].delta).toBeCloseTo(25) // 1 * 1.0 * 25
 		expect(Math.abs(logs[1].delta)).toBeGreaterThan(Math.abs(logs[0].delta))
 	})
+
+	test('a vote change reuses the original cast-time weight, not the voter\'s current score (CodeRabbit)', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com', honestyScore: 100 })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+		// The voter's score drops to the floor after casting — a change must
+		// not re-price the already-cast vote against this new value.
+		await User.findByIdAndUpdate(voter.id, { honestyScore: 0 })
+
+		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: -1 })
+
+		const voteRow = await Vote.findOne({ voterId: voter.id, targetType: 'opinion', targetId: opinion.id })
+
+		expect(voteRow?.voterWeightAtVote).toBe(1) // unchanged from the original cast, not recomputed to ~0.2
+
+		const deleteResponse = await request(app)
+			.delete('/votes')
+			.set('Cookie', cookie)
+			.send({ targetType: 'opinion', targetId: opinion.id })
+
+		expect(deleteResponse.status).toBe(204)
+
+		// Create -> change -> remove, with a shared weight throughout, nets to
+		// exactly the baseline — not just close to it (see audit #1's fix).
+		const score = await waitForHonestyScore(author.id, current => current === 50)
+
+		expect(score).toBe(50)
+		expect(await HonestyLog.countDocuments({ userId: author.id })).toBe(0)
+	})
 })
 
 describe('honesty score recalculation', () => {

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -352,7 +352,18 @@ describe('honesty score recalculation', () => {
 		await request(app).post('/votes').set('Cookie', cookie).send({ targetType: 'opinion', targetId: opinion.id, voteValue: -1 })
 		const score = await waitForHonestyScore(author.id, current => current < 50)
 
-		expect(score).toBeLessThan(50)
+		// Exact, not just "less than 50": FIX 1 replaces (not appends to) the
+		// single HonestyLog entry tied to this vote, so there's exactly one
+		// entry after the change (delta = -1 * 1.0 * 25) and its weighted
+		// "average" is just that one value, with no timing-dependent wobble.
+		// The weak toBeLessThan(50) this replaced would have passed just as
+		// happily on the pre-fix, provably wrong value of 37.5 (see the audit).
+		expect(score).toBe(25)
+
+		const logs = await HonestyLog.find({ userId: author.id })
+
+		expect(logs).toHaveLength(1)
+		expect(logs[0].delta).toBe(-25)
 	})
 
 	test('triggers on vote delete — reverses the honesty-log contribution', async() => {

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -420,6 +420,30 @@ describe('DELETE /votes', () => {
 		expect(response.status).toBe(204)
 		expect(await Vote.countDocuments({ targetType: 'opinion', targetId: opinion.id })).toBe(0)
 	})
+
+	test('ignores a body-supplied voterId — cannot remove someone else\'s vote by curling directly (audit #5)', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const realVoter = await seedUser({ username: 'real-voter', email: 'real-voter@example.com' })
+		const impersonationTarget = await seedUser({ username: 'someone-else', email: 'else@example.com' })
+		const opinion = await seedOpinion(author.id)
+
+		await request(app).post('/votes').set('Cookie', sessionCookieFor(realVoter)).send({
+			targetType: 'opinion', targetId: opinion.id, voteValue: 1
+		})
+
+		// The attacker has their OWN session (realVoter's), but forges a
+		// different voterId in the body hoping to delete someone else's vote
+		// — or, as here, one that doesn't even exist for that forged id.
+		const response = await request(app)
+			.delete('/votes')
+			.set('Cookie', sessionCookieFor(realVoter))
+			.send({ voterId: impersonationTarget.id, targetType: 'opinion', targetId: opinion.id })
+
+		// Succeeds — but removes realVoter's own vote (the cookie's real
+		// owner), not anything belonging to the forged voterId.
+		expect(response.status).toBe(204)
+		expect(await Vote.countDocuments({ voterId: realVoter.id, targetType: 'opinion', targetId: opinion.id })).toBe(0)
+	})
 })
 
 describe('net vote count on opinion listings', () => {

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -1,8 +1,8 @@
 import cookieParser from 'cookie-parser'
 import express from 'express'
-import mongoose from 'mongoose'
 import request from 'supertest'
 import { HonestyLog } from '../../database/models/honesty-log'
+import { RateLimitEvent } from '../../database/models/RateLimitEvent'
 import { TrailerOpinion } from '../../database/models/trailer-opinion'
 import { User, UserDocument } from '../../database/models/User'
 import { Vote } from '../../database/models/vote'
@@ -185,17 +185,14 @@ describe('POST /votes', () => {
 		expect(votesForTarget).toHaveLength(1)
 	})
 
-	test('rate limits after 100 votes in the last hour', async() => {
+	test('rate limits after 100 vote attempts in the last hour', async() => {
 		const voter = await seedUser()
 
-		await Vote.insertMany(
-			Array.from({ length: 100 }, () => ({
-				voterId: voter.id,
-				targetType: 'opinion',
-				targetId: new mongoose.Types.ObjectId(),
-				voteValue: 1,
-				voterWeightAtVote: 1
-			}))
+		// Seeded as recorded attempts (audit #8 fix), not live Vote rows —
+		// the limit is on attempts, independent of whether any of them still
+		// have a surviving Vote document.
+		await RateLimitEvent.insertMany(
+			Array.from({ length: 100 }, () => ({ scope: 'vote', userId: voter.id }))
 		)
 
 		const response = await request(app)
@@ -204,6 +201,56 @@ describe('POST /votes', () => {
 			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011', voteValue: 1 })
 
 		expect(response.status).toBe(429)
+	})
+
+	test('rate limits DELETE /votes too, sharing the same budget as POST (audit #8)', async() => {
+		const voter = await seedUser()
+
+		await RateLimitEvent.insertMany(
+			Array.from({ length: 100 }, () => ({ scope: 'vote', userId: voter.id }))
+		)
+
+		const response = await request(app)
+			.delete('/votes')
+			.set('Cookie', sessionCookieFor(voter))
+			.send({ targetType: 'opinion', targetId: '507f1f77bcf86cd799439011' })
+
+		expect(response.status).toBe(429)
+	})
+
+	test('vote-then-unvote cycling cannot evade the rate limit (audit #8)', async() => {
+		const author = await seedUser({ username: 'author', email: 'author@example.com' })
+		const voter = await seedUser({ username: 'voter', email: 'voter@example.com' })
+		const opinion = await seedOpinion(author.id)
+		const cookie = sessionCookieFor(voter)
+
+		let sawRateLimited = false
+
+		// 60 cycles is 120 attempts, over the shared 100/hr cap, even though
+		// at most one Vote document ever exists at a time — the previous
+		// live-Vote-row count would have let every single cycle through.
+		for (let cycle = 0; cycle < 60 && !sawRateLimited; cycle++) {
+			const voteResponse = await request(app)
+				.post('/votes')
+				.set('Cookie', cookie)
+				.send({ targetType: 'opinion', targetId: opinion.id, voteValue: 1 })
+
+			if (voteResponse.status === 429) {
+				sawRateLimited = true
+				break
+			}
+
+			const deleteResponse = await request(app)
+				.delete('/votes')
+				.set('Cookie', cookie)
+				.send({ targetType: 'opinion', targetId: opinion.id })
+
+			if (deleteResponse.status === 429) {
+				sawRateLimited = true
+			}
+		}
+
+		expect(sawRateLimited).toBe(true)
 	})
 })
 

--- a/server/actions/tests/votes.test.ts
+++ b/server/actions/tests/votes.test.ts
@@ -291,18 +291,16 @@ describe('honesty score recalculation', () => {
 
 		expect(deleteResponse.status).toBe(204)
 
-		// The create (+25) and reversal (-25) entries land milliseconds apart,
-		// so their time-decay weights aren't bit-for-bit identical — the score
-		// settles very close to, but not always exactly, the 50 baseline.
-		const score = await waitForHonestyScore(author.id, current => Math.abs(current - 50) < 0.01)
+		// The HonestyLog entry tied to this vote is removed outright (not
+		// offset by a reversal entry) — with no entries left for this author,
+		// the score is exactly the baseline, not just close to it.
+		const score = await waitForHonestyScore(author.id, current => current === 50)
 
-		expect(score).toBeCloseTo(50, 1)
+		expect(score).toBe(50)
 
-		const logs = await HonestyLog.find({ userId: author.id }).sort({ createdAt: 1 })
+		const logs = await HonestyLog.find({ userId: author.id })
 
-		expect(logs).toHaveLength(2)
-		expect(logs[1].reason).toBe('upvote removed')
-		expect(logs[1].delta).toBeCloseTo(-25)
+		expect(logs).toHaveLength(0)
 	})
 })
 

--- a/server/actions/votes.ts
+++ b/server/actions/votes.ts
@@ -100,17 +100,7 @@ export const castVote = async(request: Request, response: Response, next: NextFu
 			return
 		}
 
-		const [voter, config, existingVote] = await Promise.all([
-			User.findById(voterId).select('honestyScore'),
-			getConfig(),
-			Vote.findOne({ voterId, targetType, targetId })
-		])
-
-		if (!voter) {
-			response.status(401).json(UNAUTHORIZED)
-			return
-		}
-
+		const existingVote = await Vote.findOne({ voterId, targetType, targetId })
 		const previousVoteValue = existingVote?.voteValue ?? null
 
 		if (previousVoteValue === voteValue) {
@@ -120,7 +110,30 @@ export const castVote = async(request: Request, response: Response, next: NextFu
 			return
 		}
 
-		const voterWeightAtVote = computeVoterWeight(voter.honestyScore, config.voteWeightFloor)
+		let voterWeightAtVote: number
+
+		if (existingVote) {
+			// A vote change reuses the ORIGINAL cast-time weight snapshot.
+			// Recomputing from the voter's CURRENT honestyScore here would let
+			// a voter's later behavior re-price a vote they already cast —
+			// exactly what VoteDocument.voterWeightAtVote's snapshot contract
+			// rules out — and would break the exact-cancellation guarantee a
+			// create -> change -> delete cycle now relies on (the delete path
+			// reverses using this same stored weight).
+			voterWeightAtVote = existingVote.voterWeightAtVote
+		} else {
+			const [voter, config] = await Promise.all([
+				User.findById(voterId).select('honestyScore'),
+				getConfig()
+			])
+
+			if (!voter) {
+				response.status(401).json(UNAUTHORIZED)
+				return
+			}
+
+			voterWeightAtVote = computeVoterWeight(voter.honestyScore, config.voteWeightFloor)
+		}
 
 		const vote = await Vote.findOneAndUpdate(
 			{ voterId, targetType, targetId },

--- a/server/actions/votes.ts
+++ b/server/actions/votes.ts
@@ -7,6 +7,7 @@ import { User } from '../database/models/User'
 import { Vote, VoteDocument, VoteTargetType } from '../database/models/vote'
 import { getConfig } from '../lib/config'
 import { computeVoterWeight, enqueueHonestyScoreRecalculation } from '../lib/honesty-score'
+import { isUserRateLimited, recordUserAttempt } from '../lib/rate-limit'
 import { toVotePublicDTO } from '../serializers'
 import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
 
@@ -19,6 +20,9 @@ import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
 // one — can swing a score on its own the way this constant might suggest.
 const VOTE_HONESTY_DELTA_MAGNITUDE = 25
 
+// Shared budget across POST and DELETE /votes (scope 'vote') — cast,
+// change, and remove all draw from the same 100/hr cap, so cycling
+// create+delete can't double the effective throughput (audit #8).
 const VOTE_RATE_LIMIT = 100
 const VOTE_RATE_WINDOW_MS = 60 * 60 * 1000
 
@@ -41,15 +45,6 @@ function voteLabel(voteValue: 1 | -1): string {
 
 function voteReasonFor(voteValue: 1 | -1): string {
 	return `received a${voteValue === 1 ? 'n' : ''} ${voteLabel(voteValue)}`
-}
-
-async function isRateLimited(voterId: string): Promise<boolean> {
-	const count = await Vote.countDocuments({
-		voterId,
-		createdAt: { $gte: new Date(Date.now() - VOTE_RATE_WINDOW_MS) }
-	})
-
-	return count >= VOTE_RATE_LIMIT
 }
 
 // Same trust boundary as server/actions/opinions.ts and reviews.ts:
@@ -78,12 +73,18 @@ export const castVote = async(request: Request, response: Response, next: NextFu
 			return
 		}
 
-		if (await isRateLimited(voterId)) {
+		if (await isUserRateLimited('vote', voterId, VOTE_RATE_LIMIT, VOTE_RATE_WINDOW_MS)) {
 			response.status(429).json({
 				error: { code: 'RATE_LIMITED', message: 'Too many votes — try again later.' }
 			})
 			return
 		}
+
+		// Recorded here — past shape validation and the rate-limit check
+		// itself, same as server/lib/rate-limit.ts's auth attempts — so a
+		// script hammering with invalid/self/nonexistent targets still burns
+		// its budget rather than getting free retries.
+		await recordUserAttempt('vote', voterId)
 
 		const target = await TARGET_MODELS[targetType].findById(targetId).select('userId')
 
@@ -171,6 +172,17 @@ export const removeVote = async(request: Request, response: Response, next: Next
 			})
 			return
 		}
+
+		// Same shared 'vote' budget as castVote — previously unrated, which
+		// let a create-then-delete cycle dodge the cap entirely (audit #8).
+		if (await isUserRateLimited('vote', voterId, VOTE_RATE_LIMIT, VOTE_RATE_WINDOW_MS)) {
+			response.status(429).json({
+				error: { code: 'RATE_LIMITED', message: 'Too many votes — try again later.' }
+			})
+			return
+		}
+
+		await recordUserAttempt('vote', voterId)
 
 		const deletedVote = await Vote.findOneAndDelete({ voterId, targetType, targetId })
 

--- a/server/actions/votes.ts
+++ b/server/actions/votes.ts
@@ -127,14 +127,25 @@ export const castVote = async(request: Request, response: Response, next: NextFu
 			{ upsert: true, new: true, setDefaultsOnInsert: true }
 		)
 
-		const delta = previousVoteValue === null
-			? voteValue * voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
-			: (voteValue - previousVoteValue) * voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
+		// delta is this vote's full current contribution, not an incremental
+		// swing — the findOneAndUpdate below REPLACES the one HonestyLog entry
+		// tied to this vote (keyed by voteId) rather than appending a
+		// corrective entry on top of the superseded one. That's what keeps
+		// HonestyLog mirroring the live vote set 1:1: a vote that has changed
+		// three times still has exactly one log entry, reflecting only its
+		// current value, so the weighted-average recalculation never carries
+		// residue from a vote's earlier values (see server/lib/honesty-score.ts
+		// and the audit's forced-interleaving/delta-on-change findings).
+		const delta = voteValue * voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
 		const reason = previousVoteValue === null
 			? voteReasonFor(voteValue)
 			: `vote changed from ${voteLabel(previousVoteValue)} to ${voteLabel(voteValue)}`
 
-		await HonestyLog.create({ userId: target.userId, delta, reason })
+		await HonestyLog.findOneAndUpdate(
+			{ voteId: vote._id },
+			{ userId: target.userId, delta, reason, createdAt: new Date() },
+			{ upsert: true, setDefaultsOnInsert: true }
+		)
 		enqueueHonestyScoreRecalculation(target.userId.toString())
 
 		response.status(previousVoteValue === null ? 201 : 200).json(toVotePublicDTO(vote as VoteDocument))
@@ -169,16 +180,19 @@ export const removeVote = async(request: Request, response: Response, next: Next
 		}
 
 		const vote = deletedVote as unknown as VoteDocument
+
+		// Removes the entry tied to this vote outright — no reversal entry
+		// needed, since there's nothing left in the log to reverse against
+		// (see the comment on HonestyLogDocument.voteId). This also closes a
+		// gap the previous reversal-entry design had: it ran only when the
+		// target still existed, so a vote on an already-deleted target left
+		// its original contribution stuck in the log forever. Removing by
+		// voteId doesn't depend on the target existing at all.
+		await HonestyLog.deleteOne({ voteId: vote._id })
+
 		const target = await TARGET_MODELS[vote.targetType].findById(vote.targetId).select('userId')
 
-		// The target itself may have been deleted since the vote was cast —
-		// nothing to attribute the reversal to in that case, so the vote
-		// removal still succeeds, it just has no honesty-log side effect.
 		if (target) {
-			const delta = -vote.voteValue * vote.voterWeightAtVote * VOTE_HONESTY_DELTA_MAGNITUDE
-			const reason = `${voteLabel(vote.voteValue)} removed`
-
-			await HonestyLog.create({ userId: target.userId, delta, reason })
 			enqueueHonestyScoreRecalculation(target.userId.toString())
 		}
 

--- a/server/actions/votes.ts
+++ b/server/actions/votes.ts
@@ -86,6 +86,11 @@ export const castVote = async(request: Request, response: Response, next: NextFu
 		// its budget rather than getting free retries.
 		await recordUserAttempt('vote', voterId)
 
+		// DEFERRED (audit #7, documented not built): between this existence
+		// check and the vote write below, the target could in principle be
+		// deleted, leaving an orphaned Vote row. Moot today — there is no
+		// delete-opinion/delete-review endpoint anywhere in this app — but
+		// worth a second look whenever one is added.
 		const target = await TARGET_MODELS[targetType].findById(targetId).select('userId')
 
 		if (!target) {

--- a/server/database/models/RateLimitEvent.ts
+++ b/server/database/models/RateLimitEvent.ts
@@ -1,23 +1,29 @@
 import mongoose, { Schema } from 'mongoose'
 
 export interface RateLimitEventDocument extends mongoose.Document {
-	// Separates budgets per endpoint (e.g. 'request-code', 'verify-code') so
-	// exhausting one doesn't starve the other for the same user.
+	// Separates budgets per endpoint (e.g. 'request-code', 'verify-code',
+	// 'vote') so exhausting one doesn't starve the other for the same user.
 	scope: string
-	email: string
-	ip: string
+	// Auth scopes key on email/ip; the 'vote' scope keys on userId instead
+	// (already-authenticated, no email/ip involved) — exactly one of
+	// email/ip or userId is populated depending on scope, never all three.
+	email: string | null
+	ip: string | null
+	userId: string | null
 	createdAt: Date
 }
 
 const rateLimitEventSchema = new Schema<RateLimitEventDocument>({
 	scope: { type: String, required: true },
-	email: { type: String, required: true },
-	ip: { type: String, required: true },
+	email: { type: String, default: null },
+	ip: { type: String, default: null },
+	userId: { type: String, default: null },
 	createdAt: { type: Date, default: Date.now }
 })
 
 rateLimitEventSchema.index({ scope: 1, email: 1, createdAt: 1 })
 rateLimitEventSchema.index({ scope: 1, ip: 1, createdAt: 1 })
+rateLimitEventSchema.index({ scope: 1, userId: 1, createdAt: 1 })
 // TTL matches the longest window a caller checks against (see server/lib/rateLimit.ts)
 // so nothing needs a separate cleanup job.
 rateLimitEventSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 })

--- a/server/database/models/honesty-log.ts
+++ b/server/database/models/honesty-log.ts
@@ -4,6 +4,14 @@ export interface HonestyLogDocument extends mongoose.Document {
 	userId: mongoose.Types.ObjectId
 	delta: number
 	reason: string
+	// Links this entry to the Vote that produced it, so a vote change/delete
+	// (server/actions/votes.ts) can replace or remove the exact entry
+	// instead of appending a corrective one on top of it — HonestyLog then
+	// always mirrors the live vote set 1:1, so the weighted-average
+	// recalculation (server/lib/honesty-score.ts) never carries residue
+	// from a superseded or retracted vote. null for entries that don't
+	// originate from a vote (none yet, but the field exists for them).
+	voteId: mongoose.Types.ObjectId | null
 	createdAt: Date
 }
 
@@ -11,12 +19,17 @@ const honestyLogSchema = new Schema<HonestyLogDocument>({
 	userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
 	delta: { type: Number, required: true },
 	reason: { type: String, required: true },
+	voteId: { type: Schema.Types.ObjectId, ref: 'Vote', default: null },
 	createdAt: { type: Date, default: Date.now }
 })
 
 // Recalculation job (server/lib/honesty-score.ts) reads a user's entries
 // ordered by recency — index matches that access pattern.
 honestyLogSchema.index({ userId: 1, createdAt: -1 })
+
+// Sparse since only vote-originated entries set this — backs the
+// replace-by-voteId / delete-by-voteId writes in server/actions/votes.ts.
+honestyLogSchema.index({ voteId: 1 }, { sparse: true })
 
 export const HonestyLog =
 	mongoose.models.HonestyLog || mongoose.model<HonestyLogDocument>('HonestyLog', honestyLogSchema)

--- a/server/database/models/vote.ts
+++ b/server/database/models/vote.ts
@@ -26,9 +26,4 @@ const voteSchema = new Schema<VoteDocument>({
 // Enforces one vote per user per target at the database level, not just app logic.
 voteSchema.index({ voterId: 1, targetType: 1, targetId: 1 }, { unique: true })
 
-// Matches the per-voter rate-limit window query in server/actions/votes.ts
-// (count a voter's votes in the last hour) — the unique index above only
-// has voterId as a usable prefix for that query, not createdAt.
-voteSchema.index({ voterId: 1, createdAt: 1 })
-
 export const Vote = mongoose.models.Vote || mongoose.model<VoteDocument>('Vote', voteSchema)

--- a/server/database/models/vote.ts
+++ b/server/database/models/vote.ts
@@ -26,4 +26,11 @@ const voteSchema = new Schema<VoteDocument>({
 // Enforces one vote per user per target at the database level, not just app logic.
 voteSchema.index({ voterId: 1, targetType: 1, targetId: 1 }, { unique: true })
 
+// Backs the netVoteCount aggregation (server/lib/vote-counts.ts), which
+// matches on {targetType, targetId: {$in: [...]}} with no voterId — the
+// unique index above can't serve that (voterId isn't in the query at all),
+// so it was running a full collection scan on every opinions/reviews page
+// load (audit #13, confirmed via .explain()).
+voteSchema.index({ targetType: 1, targetId: 1 })
+
 export const Vote = mongoose.models.Vote || mongoose.model<VoteDocument>('Vote', voteSchema)

--- a/server/lib/honesty-score.ts
+++ b/server/lib/honesty-score.ts
@@ -51,6 +51,20 @@ export function computeVoterWeight(honestyScore: number, voteWeightFloor: number
 	return voteWeightFloor + scoreFraction * (1 - voteWeightFloor)
 }
 
+// DEFERRED (audit #12, documented not built): this walks the user's ENTIRE
+// HonestyLog history on every single recalculation. The query itself is
+// indexed (confirmed via .explain() — IXSCAN/FETCH, no collection scan), so
+// this isn't a missing-index problem, it's an algorithmic one: cost is
+// O(lifetime log entries), and since every vote/change/delete against this
+// user re-triggers a full walk, cumulative cost over their lifetime grows
+// O(N^2) in their total vote count. Acceptable at current volume; a popular
+// reviewer receiving thousands of votes would need either a bounded window
+// (very old entries beyond a few half-lives barely move the average anyway)
+// or an incrementally-maintained running average instead of a full
+// recompute each time. FIX 1's voteId linkage (each vote maps to exactly
+// one log entry) makes an incremental approach more tractable later, since
+// a single vote's effect on the aggregate becomes a well-defined, isolable
+// update rather than one of an unbounded, unlinked pile of entries.
 export async function recalculateHonestyScore(userId: string): Promise<number> {
 	const logs = await HonestyLog.find({ userId }).select('delta createdAt').lean()
 	const score = computeDecayedHonestyScore(logs.map(log => ({ delta: log.delta, createdAt: log.createdAt })))

--- a/server/lib/honesty-score.ts
+++ b/server/lib/honesty-score.ts
@@ -60,11 +60,42 @@ export async function recalculateHonestyScore(userId: string): Promise<number> {
 	return score
 }
 
+// Chains recalculations per user so two overlapping calls (e.g. two votes
+// landing on the same target within milliseconds) never interleave their
+// read and write: without this, a recalculation started from stale data
+// could finish its write *after* a later, more complete recalculation,
+// silently reverting the score until some future event happens to trigger
+// another recalc (audit #2 — see the forced-interleaving regression test in
+// server/lib/tests/honesty-score-recalculation.test.ts for a concrete
+// repro). Entries are removed once their chain drains so this map doesn't
+// grow unbounded.
+//
+// This only guarantees ordering within a single Node process. A
+// horizontally scaled deployment (multiple server instances) would need a
+// database-level guard instead (e.g. an optimistic version check on the
+// User document) — not needed at this app's current single-process scale.
+const recalculationQueueByUserId = new Map<string, Promise<void>>()
+
 // Fire-and-forget entry point for vote/log writes: caller does not await
 // this, so a slow or failing recalculation never blocks the request that
 // triggered it.
 export function enqueueHonestyScoreRecalculation(userId: string): void {
-	recalculateHonestyScore(userId).catch(error => {
-		console.error('Honesty score recalculation failed:', error.message)
-	})
+	const previous = recalculationQueueByUserId.get(userId) ?? Promise.resolve()
+
+	const next = previous
+		.catch(() => {
+			// A prior failure must not break the chain for calls queued after it.
+		})
+		.then(() => recalculateHonestyScore(userId))
+		.then(() => {})
+		.catch(error => {
+			console.error('Honesty score recalculation failed:', error.message)
+		})
+		.finally(() => {
+			if (recalculationQueueByUserId.get(userId) === next) {
+				recalculationQueueByUserId.delete(userId)
+			}
+		})
+
+	recalculationQueueByUserId.set(userId, next)
 }

--- a/server/lib/rate-limit.ts
+++ b/server/lib/rate-limit.ts
@@ -28,3 +28,26 @@ export async function isRateLimited(scope: string, email: string, ip: string): P
 export async function recordAttempt(scope: string, email: string, ip: string): Promise<void> {
 	await RateLimitEvent.create({ scope, email, ip })
 }
+
+/*
+ * Per-user counterpart to isRateLimited/recordAttempt above, for
+ * already-authenticated actions with no email/ip involved (votes). Counts
+ * permanently-recorded attempts, not surviving rows in whatever resource the
+ * limit is meant to bound — server/actions/votes.ts previously counted
+ * live Vote documents, which a create-then-delete cycle could use to evade
+ * the cap entirely (audit #8). limit/window are passed in rather than
+ * hardcoded here since different callers may need different budgets.
+ */
+export async function isUserRateLimited(
+	scope: string, userId: string, limit: number, windowMs: number
+): Promise<boolean> {
+	const count = await RateLimitEvent.countDocuments({
+		scope, userId, createdAt: { $gte: new Date(Date.now() - windowMs) }
+	})
+
+	return count >= limit
+}
+
+export async function recordUserAttempt(scope: string, userId: string): Promise<void> {
+	await RateLimitEvent.create({ scope, userId })
+}

--- a/server/lib/tests/honesty-score-recalculation.test.ts
+++ b/server/lib/tests/honesty-score-recalculation.test.ts
@@ -1,7 +1,27 @@
 import { HonestyLog } from '../../database/models/honesty-log'
 import { User } from '../../database/models/User'
 import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
-import { recalculateHonestyScore } from '../honesty-score'
+import { computeDecayedHonestyScore, enqueueHonestyScoreRecalculation, recalculateHonestyScore } from '../honesty-score'
+
+async function waitForHonestyScore(
+	userId: string,
+	predicate: (score: number) => boolean,
+	timeoutMs = 2000
+): Promise<number> {
+	const start = Date.now()
+
+	while (Date.now() - start < timeoutMs) {
+		const user = await User.findById(userId).select('honestyScore')
+
+		if (user && predicate(user.honestyScore)) {
+			return user.honestyScore
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 10))
+	}
+
+	throw new Error('Timed out waiting for honesty score to update')
+}
 
 beforeAll(async() => {
 	await connectTestDatabase()
@@ -40,5 +60,48 @@ describe('recalculateHonestyScore', () => {
 		const reloaded = await User.findById(user.id)
 
 		expect(reloaded?.honestyScore).toBe(50)
+	})
+})
+
+describe('enqueueHonestyScoreRecalculation concurrency (audit #2 regression)', () => {
+	test('two calls queued back to back for the same user never lose an update', async() => {
+		const user = await User.create({ username: 'critic9', email: 'critic9@example.com' })
+
+		// Deltas deliberately differ (not both +25) — if the earlier call's
+		// stale read were allowed to overwrite the later call's complete one,
+		// the two candidate results would be distinguishable rather than
+		// coincidentally identical.
+		await HonestyLog.create({ userId: user.id, delta: 25, reason: 'vote A' })
+		enqueueHonestyScoreRecalculation(user.id)
+
+		await HonestyLog.create({ userId: user.id, delta: -25, reason: 'vote B' })
+		enqueueHonestyScoreRecalculation(user.id)
+
+		const logs = await HonestyLog.find({ userId: user.id }).select('delta createdAt').lean()
+		const trueScore = computeDecayedHonestyScore(logs.map(log => ({ delta: log.delta, createdAt: log.createdAt })))
+
+		await waitForHonestyScore(user.id, current => Math.abs(current - trueScore) < 0.001)
+
+		const reloaded = await User.findById(user.id)
+
+		expect(reloaded?.honestyScore).toBeCloseTo(trueScore, 3)
+	})
+
+	test('many overlapping recalculations for the same user still converge on the complete result', async() => {
+		const user = await User.create({ username: 'critic10', email: 'critic10@example.com' })
+
+		for (let index = 0; index < 10; index++) {
+			await HonestyLog.create({ userId: user.id, delta: index % 2 === 0 ? 10 : -10, reason: `event ${index}` })
+			enqueueHonestyScoreRecalculation(user.id)
+		}
+
+		const logs = await HonestyLog.find({ userId: user.id }).select('delta createdAt').lean()
+		const trueScore = computeDecayedHonestyScore(logs.map(log => ({ delta: log.delta, createdAt: log.createdAt })))
+
+		await waitForHonestyScore(user.id, current => Math.abs(current - trueScore) < 0.001)
+
+		const reloaded = await User.findById(user.id)
+
+		expect(reloaded?.honestyScore).toBeCloseTo(trueScore, 3)
 	})
 })

--- a/server/lib/vote-counts.ts
+++ b/server/lib/vote-counts.ts
@@ -10,6 +10,14 @@ export interface VoteSummary {
 	viewerVote: 1 | -1 | null
 }
 
+// DEFERRED (audit #11, documented not built — no real traffic yet):
+// netVoteCount is computed live via aggregation on every page load, not
+// denormalized. Fine at current scale; before real traffic this needs a
+// counter cache instead — e.g. $inc a netVoteCount field on the
+// TrailerOpinion/Review document itself at vote create/change/delete time
+// (server/actions/votes.ts), so listing pages stop touching the Votes
+// collection at all.
+//
 // Keyed by targetId string so callers can look up a summary per item
 // without caring about ObjectId identity comparisons.
 export async function getVoteSummaries(

--- a/server/tmdb-wrapper/movie-db-wrapper.ts
+++ b/server/tmdb-wrapper/movie-db-wrapper.ts
@@ -49,7 +49,7 @@ export default class TmdbMovie {
 
   async getMovieDetails(movieId: string) {
     const { data } = await axios.get(
-      `${apiBaseURL}/movie/${movieId}?api_key=${this.apiKey}&language=${this.language}`
+      `${apiBaseURL}/movie/${encodeURIComponent(movieId)}?api_key=${this.apiKey}&language=${this.language}`
     )
 
     return data
@@ -57,7 +57,7 @@ export default class TmdbMovie {
 
   async getMovieImages(movieId: string) {
     const { data } = await axios.get(
-      `${apiBaseURL}/movie/${movieId}/images?api_key=${this.apiKey}&language=${this.language}`
+      `${apiBaseURL}/movie/${encodeURIComponent(movieId)}/images?api_key=${this.apiKey}&language=${this.language}`
     )
 
     return data
@@ -65,7 +65,7 @@ export default class TmdbMovie {
 
   async getMovieCredits(movieId: string) {
     const { data } = await axios.get(
-      `${apiBaseURL}/movie/${movieId}/credits?api_key=${this.apiKey}&language=${this.language}`
+      `${apiBaseURL}/movie/${encodeURIComponent(movieId)}/credits?api_key=${this.apiKey}&language=${this.language}`
     )
 
     return data
@@ -73,7 +73,7 @@ export default class TmdbMovie {
 
   async getMovieVideos(movieId: string) {
     const { data } = await axios.get(
-      `${apiBaseURL}/movie/${movieId}/videos?api_key=${this.apiKey}&language=${this.language}`
+      `${apiBaseURL}/movie/${encodeURIComponent(movieId)}/videos?api_key=${this.apiKey}&language=${this.language}`
     )
 
     return data


### PR DESCRIPTION
## Look here first: FIX 1 (voteId-linkage redesign) and FIX 2 (serialized recalc)

**FIX 1** is a redesign, not a patch, and is the commit most worth scrutinizing. The prior vote-change design logged the *net swing* as a new HonestyLog entry on top of the original one (never removed). That's wrong: `computeDecayedHonestyScore` is a weighted **average**, not a sum, so the superseded entry keeps diluting the denominator forever. Audit repro with real numbers: vote +1 then change to -1 left the target author at **37.5**; a fresh -1 vote from the same voter gives **25**. Same final `Vote` row in both cases, different score.

The fix links each HonestyLog entry to its originating Vote via a new nullable `voteId`. A vote change now *replaces* that one entry (not appends); a delete removes it outright. HonestyLog mirrors the live vote set 1:1 — no residue, ever. Please check: `server/actions/votes.ts`'s `castVote`/`removeVote` (the `HonestyLog.findOneAndUpdate({voteId: vote._id}, ...)` / `HonestyLog.deleteOne({voteId: vote._id})` calls), and the property test in `server/actions/tests/votes-property.test.ts` (4 sequences — repeated changes, delete-then-revote, full cycle back to no vote, multi-voter interleaving — each asserting HonestyLog exactly matches a from-scratch vote of the final state).

**FIX 2** closes a real, deterministically-reproduced concurrent-write race: `recalculateHonestyScore` was a plain read-then-write with no synchronization. Two overlapping recalcs for the same author (e.g. two votes landing within milliseconds) could interleave so a stale, incomplete recalc's write lands *after* a later, complete one — silently reverting the score until some future event happens to trigger another recalc. Reproduced deterministically during the audit (forced interleaving: correct write of 50, then a stale write of 75 lands after it and wins). Fixed by chaining recalculations per user through a `Map` of in-flight promises in `server/lib/honesty-score.ts`, so overlapping calls for the same user run their read+write strictly in enqueue order. This only guarantees ordering within a single Node process — noted in the code as a limitation, not needed at this app's current single-process scale. Regression tests in `server/lib/tests/honesty-score-recalculation.test.ts`.

## Everything else in this PR (in commit order)

- **FIX 3** — vote rate limiting counted live `Vote` rows, which a create-then-delete cycle could use to evade the 100/hr cap indefinitely (each delete frees up room for another "free" vote). Switched to the same permanent-attempt-log pattern the auth flows already use (`RateLimitEvent`, now also supporting a `userId` dimension). `DELETE /votes` previously had no rate limit at all — it now shares the same budget as `POST /votes`, so cycling between them can't double the effective throughput. Test runs 60 real vote/unvote cycles (120 attempts) through the actual endpoints and confirms the limit trips.
- **FIX 4** — missing index. The `netVoteCount` aggregation matches on `{targetType, targetId: $in}` with no `voterId`, so the existing unique index couldn't serve it — full collection scan on every opinions/reviews page load. Confirmed via `.explain()` before (COLLSCAN, 200/200 docs examined) and after (IXSCAN, 70 docs — exactly the relevant votes).
- **FIX 5** — vote change was recomputing `voterWeightAtVote` from the voter's *current* honesty score instead of reusing the original cast-time snapshot, contradicting the documented snapshot contract and breaking FIX 1's exact-cancellation guarantee. Fixed and regression-tested (voter's score drops between cast and change; weight stays pinned; full cycle converges to exactly baseline with zero leftover log entries).
- **FIX 6** — the movie detail loader's opinions/reviews list fetches didn't forward the session cookie (the mutation actions already did) — `viewerVote` always came back null for logged-in viewers, so the active vote button state never rendered.
- **FIX 7** — vote buttons now disable while their fetcher submission is in flight, so rapid clicks can't fire overlapping mutations that land out of order.
- **FIX 8** — `getDetails`/`getCredits`/`getImages`/`getVideos` all did `String(request.query.movieId)` with zero validation before interpolating it into the upstream TMDB URL — a missing key, a repeated key (Express parses it as an array), or any non-numeric value went straight through. Added shared validation (400 before any TMDB call) plus `encodeURIComponent` at the wrapper boundary as defense in depth. Checked the opinions/reviews/votes routes for the same gap — they already validate properly (`Number.isInteger`, `mongoose.isValidObjectId`), no change needed there.
- **FIX 9** — `DELETE /votes` never read a body-supplied `voterId` (safe by inspection, identity always came from the session cookie, same as `POST /votes`), but had no test proving it. Added the equivalent impersonation test.
- **Test hardening** — the "vote change" test asserted only `toBeLessThan(50)`, which the pre-fix bug's wrong value (37.5) satisfied just as happily as the correct one (25) — that's why it never caught FIX 1's bug. Replaced with an exact assertion. Added the 4-scenario property test described above.
- **Deferred, documented only** (per the audit's own recommendation — not built): a code comment at each spot noting audit #9 (viewerVote's cookie-personalization is a caching hazard for whoever adds a shared cache later), #11 (netVoteCount needs a counter-cache before real traffic), #12 (recalculation cost is O(N) per call / O(N²) over a user's lifetime — FIX 1's voteId linkage makes an incremental approach more tractable when needed), and #7 (a TOCTOU window in `castVote`'s target-existence check, moot until a delete-opinion/delete-review endpoint exists).

## Caveat: FIX 6 and FIX 7 have no automated regression coverage

This repo has no client-side test runner configured (no test script, no Jest/Vitest for `client/`) — confirmed before writing these fixes, not skipped by oversight. Both were verified by code inspection and `pnpm typecheck`, not by an automated test. If a client test runner gets added later, both are worth covering: FIX 6 (cookie forwarded → `viewerVote` populates → correct button renders active) and FIX 7 (rapid clicks → second click is a no-op while the first is pending).

## Test plan
- [x] `pnpm exec tsc --noEmit` (server) and `pnpm typecheck` (client) — both clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 21 suites, 133 tests, all passing
- [x] FIX 1/2 both verified against real numbers before the fix (audit) and exact/deterministic assertions after (this PR) — see `server/actions/tests/votes-property.test.ts` and `server/lib/tests/honesty-score-recalculation.test.ts`
- [x] FIX 4 verified via real `.explain()` output, not just code reading
- [ ] Full page smoke test (buttons rendering/toggling in an actual browser) still pending a local run — this environment has no TMDB `API_KEY` for the movie-detail loader's other calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vote and unvote actions now share rate limits, helping prevent excessive voting activity.
  - Vote changes preserve accurate contribution and honesty-score updates.
- **Bug Fixes**
  - Personalized opinions and reviews now correctly reflect the viewer’s session.
  - Vote buttons are temporarily disabled while submissions are processing.
  - Invalid movie requests are rejected safely, including malformed or repeated identifiers.
- **Tests**
  - Expanded coverage for movie validation, voting limits, vote changes, and honesty-score accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->