### PR TITLE
Add user profile page with public reviews and opinions

### DIFF
--- a/client/src/features/movies/opinion-section.tsx
+++ b/client/src/features/movies/opinion-section.tsx
@@ -53,7 +53,9 @@ function OpinionList(
         <Card key={opinion.id} withBorder padding="sm" radius="md">
           <Group gap="xs" justify="space-between">
             <Group gap="xs">
-              <Text fw={500}>{opinion.author.username}</Text>
+              <Text component={Link} to={`/users/${opinion.author.username}`} fw={500}>
+                {opinion.author.username}
+              </Text>
               {opinion.author.isLowTrust ? <LowTrustBadge /> : null}
               <Text size="sm" c="dimmed">Honesty {opinion.author.honestyScore}</Text>
               <Badge variant="light" color="orange">Hype {opinion.hypeLevel}/5</Badge>

--- a/client/src/features/movies/review-section.tsx
+++ b/client/src/features/movies/review-section.tsx
@@ -67,7 +67,9 @@ function ReviewList(
         <Card key={review.id} withBorder padding="sm" radius="md">
           <Group gap="xs" justify="space-between">
             <Group gap="xs">
-              <Text fw={500}>{review.author.username}</Text>
+              <Text component={Link} to={`/users/${review.author.username}`} fw={500}>
+                {review.author.username}
+              </Text>
               {review.author.isLowTrust ? <LowTrustBadge /> : null}
               <Text size="sm" c="dimmed">Honesty {review.author.honestyScore}</Text>
               <Badge variant="light" color="teal">Score {review.score}/10</Badge>

--- a/client/src/features/users/account-settings-shell.tsx
+++ b/client/src/features/users/account-settings-shell.tsx
@@ -1,0 +1,14 @@
+import { Divider, Stack, Text, Title } from '@mantine/core'
+import React from 'react'
+
+// Own-profile-only section. Shell for now — the delete-account feature
+// fills this in with the actual confirmation UI.
+export default function AccountSettingsShell() {
+	return (
+		<Stack gap="xs" mt="lg">
+			<Divider />
+			<Title order={3}>Account settings</Title>
+			<Text c="dimmed" size="sm">More settings coming soon.</Text>
+		</Stack>
+	)
+}

--- a/client/src/features/users/types.ts
+++ b/client/src/features/users/types.ts
@@ -1,0 +1,37 @@
+export interface UserProfile {
+	username: string
+	honestyScore: number
+	isLowTrust: boolean
+	isPhoneVerified: boolean
+	createdAt: string
+}
+
+export interface PaginatedList<T> {
+	page: number
+	totalPages: number
+	totalResults: number
+	results: T[]
+}
+
+export interface ReviewActivityItem {
+	id: string
+	movieId: number
+	score: number
+	comment: string
+	createdAt: string
+}
+
+export interface OpinionActivityItem {
+	id: string
+	movieId: number
+	hypeLevel: number
+	comment: string
+	createdAt: string
+}
+
+export interface ActivityMovie {
+	id: number
+	title: string
+	posterUrl: string | null
+	releaseYear: string | null
+}

--- a/client/src/features/users/user-profile.tsx
+++ b/client/src/features/users/user-profile.tsx
@@ -1,0 +1,83 @@
+import { Badge, Container, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core'
+import React from 'react'
+import ProfileActivityCard from '../../ui/profile-activity-card'
+import AccountSettingsShell from './account-settings-shell'
+import type { ActivityMovie, OpinionActivityItem, PaginatedList, ReviewActivityItem, UserProfile } from './types'
+
+const UNKNOWN_MOVIE: ActivityMovie = { id: 0, title: 'Unknown movie', posterUrl: null, releaseYear: null }
+
+function formatMemberSince(createdAt: string): string {
+	return new Date(createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long' })
+}
+
+export default function UserProfilePage({
+	profile, reviews, opinions, movieById, isOwnProfile
+}: {
+	profile: UserProfile
+	reviews: PaginatedList<ReviewActivityItem>
+	opinions: PaginatedList<OpinionActivityItem>
+	movieById: Record<number, ActivityMovie>
+	isOwnProfile: boolean
+}) {
+	return (
+		<Container size="lg" py="lg">
+			<Group gap="xs">
+				<Title order={1}>{profile.username}</Title>
+				{profile.isLowTrust ? <Badge color="red" variant="light">Low trust</Badge> : null}
+				{profile.isPhoneVerified ? <Badge color="blue" variant="light">Verified</Badge> : null}
+			</Group>
+			<Group gap="md" mt="xs">
+				<Text c="dimmed">Honesty score {profile.honestyScore}</Text>
+				<Text c="dimmed">Member since {formatMemberSince(profile.createdAt)}</Text>
+			</Group>
+
+			{isOwnProfile ? <AccountSettingsShell /> : null}
+
+			<Stack gap="md" mt="xl">
+				<Group gap="xs">
+					<Title order={2}>Seen</Title>
+					<Badge color="teal" variant="filled">Reviews</Badge>
+				</Group>
+				{reviews.results.length === 0 ? (
+					<Text c="dimmed" size="sm">No reviews yet.</Text>
+				) : (
+					<SimpleGrid cols={{ base: 2, sm: 3, md: 5 }}>
+						{reviews.results.map(review => (
+							<ProfileActivityCard
+								key={review.id}
+								movie={movieById[review.movieId] ?? { ...UNKNOWN_MOVIE, id: review.movieId }}
+								kind="review"
+								score={review.score}
+								hypeLevel={null}
+								comment={review.comment}
+							/>
+						))}
+					</SimpleGrid>
+				)}
+			</Stack>
+
+			<Stack gap="md" mt="xl">
+				<Group gap="xs">
+					<Title order={2}>Unseen</Title>
+					<Badge color="orange" variant="filled">Opinions</Badge>
+				</Group>
+				{opinions.results.length === 0 ? (
+					<Text c="dimmed" size="sm">No opinions yet.</Text>
+				) : (
+					<SimpleGrid cols={{ base: 2, sm: 3, md: 5 }}>
+						{opinions.results.map(opinion => (
+							<ProfileActivityCard
+								key={opinion.id}
+								movie={movieById[opinion.movieId] ?? { ...UNKNOWN_MOVIE, id: opinion.movieId }}
+								kind="opinion"
+								score={null}
+								hypeLevel={opinion.hypeLevel}
+								comment={opinion.comment}
+							/>
+						))}
+					</SimpleGrid>
+				)}
+			</Stack>
+		</Container>
+	)
+}

--- a/client/src/routes/users.$username.tsx
+++ b/client/src/routes/users.$username.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import UserProfilePage from '../features/users/user-profile'
+import type { ActivityMovie, OpinionActivityItem, PaginatedList, ReviewActivityItem, UserProfile } from '../features/users/types'
+import { getSession } from '../session.server'
+import type { Route } from './+types/users.$username'
+
+const API_URL = process.env.API_URL ?? 'http://localhost:5000'
+
+const EMPTY_LIST = { page: 1, totalPages: 1, totalResults: 0, results: [] }
+
+interface RawMovieDetailsDTO {
+	id: number
+	title: string
+	poster_path: string | null
+	release_date: string
+}
+
+interface UserProfileLoaderData {
+	profile: UserProfile
+	reviews: PaginatedList<ReviewActivityItem>
+	opinions: PaginatedList<OpinionActivityItem>
+	movieById: Record<number, ActivityMovie>
+	isOwnProfile: boolean
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+	if (!loaderData) {
+		return [{ title: 'User not found — criticseven' }]
+	}
+
+	return [{ title: `${loaderData.profile.username} — criticseven` }]
+}
+
+export async function loader({ request, params }: Route.LoaderArgs): Promise<UserProfileLoaderData> {
+	// Same cookie-forwarding rule as the movie-detail loader: without it,
+	// viewerVote-equivalent personalization (here, isOwnProfile) can't be
+	// computed, and Express never sees the viewer's session on these GETs.
+	const cookie = request.headers.get('Cookie') ?? ''
+
+	const [profileResponse, reviewsResponse, opinionsResponse, session] = await Promise.all([
+		fetch(`${API_URL}/users/${params.username}`),
+		fetch(`${API_URL}/users/${params.username}/reviews`, { headers: { Cookie: cookie } }),
+		fetch(`${API_URL}/users/${params.username}/opinions`, { headers: { Cookie: cookie } }),
+		getSession(request)
+	])
+
+	if (!profileResponse.ok) {
+		throw new Response('User not found', { status: profileResponse.status === 404 ? 404 : 502 })
+	}
+
+	const profile = (await profileResponse.json()) as UserProfile
+	const reviews = reviewsResponse.ok
+		? ((await reviewsResponse.json()) as PaginatedList<ReviewActivityItem>)
+		: EMPTY_LIST
+	const opinions = opinionsResponse.ok
+		? ((await opinionsResponse.json()) as PaginatedList<OpinionActivityItem>)
+		: EMPTY_LIST
+
+	// Neither Review nor TrailerOpinion stores a denormalized movie
+	// title/poster, so the profile's activity cards need a second, batched
+	// round trip per distinct movieId — same TMDB-details endpoint the
+	// movie-detail loader already uses, just parallelized across the set.
+	const movieIds = Array.from(new Set([
+		...reviews.results.map(review => review.movieId),
+		...opinions.results.map(opinion => opinion.movieId)
+	]))
+
+	const movieDetailsResponses = await Promise.all(
+		movieIds.map(movieId => fetch(`${API_URL}/movies/details?movieId=${movieId}`))
+	)
+	const movieDetails = await Promise.all(
+		movieDetailsResponses.map(response => (response.ok ? (response.json() as Promise<RawMovieDetailsDTO>) : null))
+	)
+
+	const movieById: Record<number, ActivityMovie> = {}
+
+	movieIds.forEach((movieId, index) => {
+		const details = movieDetails[index]
+
+		if (details) {
+			movieById[movieId] = {
+				id: details.id,
+				title: details.title,
+				posterUrl: details.poster_path,
+				releaseYear: details.release_date ? details.release_date.slice(0, 4) : null
+			}
+		}
+	})
+
+	return {
+		profile,
+		reviews,
+		opinions,
+		movieById,
+		isOwnProfile: session.get('username') === params.username
+	}
+}
+
+export default function UserProfileRoute({ loaderData }: Route.ComponentProps) {
+	return (
+		<UserProfilePage
+			profile={loaderData.profile}
+			reviews={loaderData.reviews}
+			opinions={loaderData.opinions}
+			movieById={loaderData.movieById}
+			isOwnProfile={loaderData.isOwnProfile}
+		/>
+	)
+}

--- a/client/src/ui/profile-activity-card.tsx
+++ b/client/src/ui/profile-activity-card.tsx
@@ -1,0 +1,27 @@
+import { Badge, Stack, Text } from '@mantine/core'
+import React from 'react'
+import MovieCard from './movie-card'
+
+export interface ProfileActivityCardProps {
+	movie: { id: number; title: string; posterUrl: string | null; releaseYear: string | null }
+	kind: 'review' | 'opinion'
+	score: number | null
+	hypeLevel: number | null
+	comment: string
+}
+
+// Deliberately typed on a minimal inline shape (not features/users' types),
+// same discipline client/src/ui/movie-card.tsx already follows, so this
+// stays ui/-safe. Composes the existing MovieCard rather than duplicating
+// its poster-tile layout.
+export default function ProfileActivityCard({ movie, kind, score, hypeLevel, comment }: ProfileActivityCardProps) {
+	return (
+		<Stack gap={4}>
+			<MovieCard id={movie.id} title={movie.title} posterUrl={movie.posterUrl} releaseYear={movie.releaseYear} />
+			<Badge variant="light" color={kind === 'review' ? 'teal' : 'orange'} size="sm">
+				{kind === 'review' ? `Score ${score}/10` : `Hype ${hypeLevel}/5`}
+			</Badge>
+			{comment ? <Text size="xs" c="dimmed" lineClamp={2}>{comment}</Text> : null}
+		</Stack>
+	)
+}

--- a/server/actions/index.ts
+++ b/server/actions/index.ts
@@ -1,4 +1,5 @@
 export * from './movies'
 export * from './opinions'
 export * from './reviews'
+export * from './users'
 export * from './votes'

--- a/server/actions/tests/opinions.test.ts
+++ b/server/actions/tests/opinions.test.ts
@@ -101,7 +101,7 @@ describe('POST /opinions', () => {
 		expect(Object.keys(response.body).sort()).toEqual(['author', 'comment', 'createdAt', 'hypeLevel', 'id', 'movieId', 'netVoteCount', 'viewerVote'].sort())
 		expect(response.body).not.toHaveProperty('userId')
 		expect(response.body.author).toEqual({
-			username: 'critic7', honestyScore: 50, isLowTrust: false, isPhoneVerified: false
+			username: 'critic7', honestyScore: 50, isLowTrust: false, isPhoneVerified: false, createdAt: user.createdAt.toISOString()
 		})
 	})
 

--- a/server/actions/tests/reviews.test.ts
+++ b/server/actions/tests/reviews.test.ts
@@ -123,7 +123,7 @@ describe('POST /reviews', () => {
 		)
 		expect(response.body).not.toHaveProperty('userId')
 		expect(response.body.author).toEqual({
-			username: 'critic7', honestyScore: 50, isLowTrust: false, isPhoneVerified: false
+			username: 'critic7', honestyScore: 50, isLowTrust: false, isPhoneVerified: false, createdAt: user.createdAt.toISOString()
 		})
 	})
 

--- a/server/actions/tests/users.test.ts
+++ b/server/actions/tests/users.test.ts
@@ -1,0 +1,156 @@
+import cookieParser from 'cookie-parser'
+import express from 'express'
+import request from 'supertest'
+import { User, UserDocument } from '../../database/models/User'
+import { Review } from '../../database/models/review'
+import { TrailerOpinion } from '../../database/models/trailer-opinion'
+import { Vote } from '../../database/models/vote'
+import userRoutes from '../../routes/user-routes'
+import { SESSION_COOKIE_NAME } from '../../session'
+import { clearTestDatabase, connectTestDatabase, disconnectTestDatabase } from '../../test-support/database'
+import { createSignedSessionCookieValue } from '../../test-support/session'
+
+const app = express()
+
+app.use(express.json())
+app.use(cookieParser())
+app.use('/users', userRoutes())
+
+const CRITERIA_SCORES = {
+	plot: 8, acting: 7, writing: 9, score: 8, directing: 6, editing: 7, cinematography: 9
+}
+
+async function seedUser(overrides: Partial<{ username: string; email: string; honestyScore: number }> = {}) {
+	return User.create({
+		username: overrides.username ?? 'critic7',
+		email: overrides.email ?? 'critic7@example.com',
+		honestyScore: overrides.honestyScore ?? 50
+	})
+}
+
+function sessionCookieFor(user: UserDocument) {
+	const value = createSignedSessionCookieValue({ userId: user.id, username: user.username })
+
+	return `${SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`
+}
+
+beforeAll(async() => {
+	await connectTestDatabase()
+	await Review.init()
+	await TrailerOpinion.init()
+	await Vote.init()
+})
+
+afterAll(async() => {
+	await disconnectTestDatabase()
+})
+
+afterEach(async() => {
+	await clearTestDatabase()
+})
+
+describe('GET /users/:username', () => {
+	test('returns the public profile DTO', async() => {
+		const user = await seedUser({ username: 'critic7', honestyScore: 62 })
+
+		const response = await request(app).get('/users/critic7')
+
+		expect(response.status).toBe(200)
+		expect(response.body).toEqual({
+			username: 'critic7',
+			honestyScore: 62,
+			isLowTrust: false,
+			isPhoneVerified: false,
+			createdAt: user.createdAt.toISOString()
+		})
+	})
+
+	test('never leaks email or phoneNumberHash', async() => {
+		await seedUser({ username: 'critic7', email: 'critic7@example.com' })
+
+		const response = await request(app).get('/users/critic7')
+
+		expect(response.body).not.toHaveProperty('email')
+		expect(response.body).not.toHaveProperty('phoneNumberHash')
+	})
+
+	test('404s for an unknown username', async() => {
+		const response = await request(app).get('/users/nobody')
+
+		expect(response.status).toBe(404)
+		expect(response.body).toEqual({
+			error: { code: 'NOT_FOUND', message: 'User not found.' }
+		})
+	})
+})
+
+describe('GET /users/:username/reviews', () => {
+	test('lists only that user\'s reviews, paginated, newest first', async() => {
+		const author = await seedUser({ username: 'critic7', email: 'critic7@example.com' })
+
+		await seedUser({ username: 'someoneElse', email: 'someone-else@example.com' })
+		await Review.create({
+			userId: author._id, movieId: 550, comment: 'First.', createdAt: new Date('2026-01-01T00:00:00.000Z'), ...CRITERIA_SCORES
+		})
+		await Review.create({
+			userId: author._id, movieId: 551, comment: 'Second.', createdAt: new Date('2026-01-02T00:00:00.000Z'), ...CRITERIA_SCORES
+		})
+
+		const response = await request(app).get('/users/critic7/reviews')
+
+		expect(response.status).toBe(200)
+		expect(response.body.totalResults).toBe(2)
+		expect(response.body.results).toHaveLength(2)
+		expect(response.body.results[0].movieId).toBe(551)
+		expect(response.body.results.every((review: { author: { username: string } }) => review.author.username === 'critic7')).toBe(true)
+	})
+
+	test('reports the requesting viewer\'s own vote on each review', async() => {
+		const author = await seedUser({ username: 'critic7', email: 'critic7@example.com' })
+		const viewer = await seedUser({ username: 'voter1', email: 'voter1@example.com' })
+		const review = await Review.create({ userId: author._id, movieId: 550, comment: '', ...CRITERIA_SCORES })
+
+		await Vote.create({ voterId: viewer._id, targetType: 'review', targetId: review._id, voteValue: 1, voterWeightAtVote: 1 })
+
+		const response = await request(app)
+			.get('/users/critic7/reviews')
+			.set('Cookie', sessionCookieFor(viewer))
+
+		expect(response.body.results[0].viewerVote).toBe(1)
+		expect(response.body.results[0].netVoteCount).toBe(1)
+	})
+
+	test('404s for an unknown username', async() => {
+		const response = await request(app).get('/users/nobody/reviews')
+
+		expect(response.status).toBe(404)
+	})
+})
+
+describe('GET /users/:username/opinions', () => {
+	test('lists only that user\'s opinions, paginated, newest first', async() => {
+		const author = await seedUser({ username: 'critic7', email: 'critic7@example.com' })
+
+		await seedUser({ username: 'someoneElse', email: 'someone-else@example.com' })
+		await TrailerOpinion.create({
+			userId: author._id, movieId: 550, hypeLevel: 3, comment: 'First.', createdAt: new Date('2026-01-01T00:00:00.000Z')
+		})
+		await TrailerOpinion.create({
+			userId: author._id, movieId: 551, hypeLevel: 5, comment: 'Second.', createdAt: new Date('2026-01-02T00:00:00.000Z')
+		})
+
+		const response = await request(app).get('/users/critic7/opinions')
+
+		expect(response.status).toBe(200)
+		expect(response.body.totalResults).toBe(2)
+		expect(response.body.results).toHaveLength(2)
+		expect(response.body.results[0].movieId).toBe(551)
+		expect(response.body.results.every((opinion: { author: { username: string } }) => opinion.author.username === 'critic7')).toBe(true)
+	})
+
+	test('404s for an unknown username', async() => {
+		const response = await request(app).get('/users/nobody/opinions')
+
+		expect(response.status).toBe(404)
+	})
+})

--- a/server/actions/users.ts
+++ b/server/actions/users.ts
@@ -1,0 +1,118 @@
+import { NextFunction, Request, Response } from 'express'
+import { User } from '../database/models/User'
+import { Review } from '../database/models/review'
+import { TrailerOpinion } from '../database/models/trailer-opinion'
+import { getConfig } from '../lib/config'
+import { getVoteSummaries } from '../lib/vote-counts'
+import { PopulatedReviewDocument, PopulatedTrailerOpinionDocument, toReviewPublicDTO, toTrailerOpinionPublicDTO } from '../serializers'
+import { toUserPublicDTO } from '../serializers/users'
+import { getAuthenticatedUserId, SESSION_COOKIE_NAME } from '../session'
+
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 50
+
+const NOT_FOUND = {
+	error: { code: 'NOT_FOUND', message: 'User not found.' }
+}
+
+export const getUserProfile = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const user = await User.findOne({ username: request.params.username })
+
+		if (!user) {
+			response.status(404).json(NOT_FOUND)
+			return
+		}
+
+		const config = await getConfig()
+
+		response.json(toUserPublicDTO(user, config.lowTrustBadgeThreshold))
+	} catch (error) {
+		next(error)
+	}
+}
+
+// Same public-listing shape as server/actions/reviews.ts's getMovieReviews,
+// scoped by author instead of by movie. viewerVote personalization follows
+// the same rule: no cookie means no viewer identity, not a 401.
+export const getUserReviews = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const user = await User.findOne({ username: request.params.username })
+
+		if (!user) {
+			response.status(404).json(NOT_FOUND)
+			return
+		}
+
+		const page = Math.max(1, Math.trunc(Number(request.query.page)) || 1)
+		const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, Math.trunc(Number(request.query.limit)) || DEFAULT_PAGE_SIZE))
+		const viewerId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
+
+		const [reviews, totalResults, config] = await Promise.all([
+			Review.find({ userId: user._id })
+				.sort({ createdAt: -1 })
+				.skip((page - 1) * pageSize)
+				.limit(pageSize)
+				.populate('userId'),
+			Review.countDocuments({ userId: user._id }),
+			getConfig()
+		])
+		const voteSummaries = await getVoteSummaries('review', reviews.map(review => review._id), viewerId)
+
+		response.json({
+			page,
+			totalPages: Math.max(1, Math.ceil(totalResults / pageSize)),
+			totalResults,
+			results: (reviews as unknown as PopulatedReviewDocument[]).map(
+				review => toReviewPublicDTO(
+					review,
+					voteSummaries.get(review.id) ?? { netVoteCount: 0, viewerVote: null },
+					config.lowTrustBadgeThreshold
+				)
+			)
+		})
+	} catch (error) {
+		next(error)
+	}
+}
+
+export const getUserOpinions = async(request: Request, response: Response, next: NextFunction) => {
+	try {
+		const user = await User.findOne({ username: request.params.username })
+
+		if (!user) {
+			response.status(404).json(NOT_FOUND)
+			return
+		}
+
+		const page = Math.max(1, Math.trunc(Number(request.query.page)) || 1)
+		const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, Math.trunc(Number(request.query.limit)) || DEFAULT_PAGE_SIZE))
+		const viewerId = getAuthenticatedUserId(request.cookies?.[SESSION_COOKIE_NAME])
+
+		const [opinions, totalResults, config] = await Promise.all([
+			TrailerOpinion.find({ userId: user._id })
+				.sort({ createdAt: -1 })
+				.skip((page - 1) * pageSize)
+				.limit(pageSize)
+				.populate('userId'),
+			TrailerOpinion.countDocuments({ userId: user._id }),
+			getConfig()
+		])
+		const voteSummaries = await getVoteSummaries('opinion', opinions.map(opinion => opinion._id), viewerId)
+
+		response.json({
+			page,
+			totalPages: Math.max(1, Math.ceil(totalResults / pageSize)),
+			totalResults,
+			results: (opinions as unknown as PopulatedTrailerOpinionDocument[]).map(
+				opinion => toTrailerOpinionPublicDTO(
+					opinion,
+					voteSummaries.get(opinion.id) ?? { netVoteCount: 0, viewerVote: null },
+					config.lowTrustBadgeThreshold
+				)
+			)
+		})
+	} catch (error) {
+		next(error)
+	}
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import authRoutes from './auth-routes'
 import movieRoutes from './movie-routes'
 import opinionRoutes from './opinion-routes'
 import reviewRoutes from './review-routes'
+import userRoutes from './user-routes'
 import voteRoutes from './vote-routes'
 
 const router = express.Router()
@@ -12,6 +13,7 @@ router.use('/movies', movieRoutes())
 router.use('/auth', authRoutes())
 router.use('/opinions', opinionRoutes())
 router.use('/reviews', reviewRoutes())
+router.use('/users', userRoutes())
 router.use('/votes', voteRoutes())
 router.get('/', getPopular)
 

--- a/server/routes/user-routes.ts
+++ b/server/routes/user-routes.ts
@@ -1,0 +1,14 @@
+import express from 'express'
+import { getUserOpinions, getUserProfile, getUserReviews } from '../actions'
+
+const userRoutes = () => {
+	const router = express.Router()
+
+	router.get('/:username', getUserProfile)
+	router.get('/:username/reviews', getUserReviews)
+	router.get('/:username/opinions', getUserOpinions)
+
+	return router
+}
+
+export default userRoutes

--- a/server/serializers/README.md
+++ b/server/serializers/README.md
@@ -15,11 +15,12 @@ TrailerOpinion, Review, Vote, etc. in Phase 2+):
 - Route handlers call the DTO before `response.send()` — raw model documents
   and raw upstream API payloads must not be sent directly.
 
-Example (built in Phase 3): `UserPublicDTO { username, honestyScore, isLowTrust, isPhoneVerified }`
-— `isPhoneVerified` feeds a future "Verified" badge the same way `isLowTrust`
-feeds the low-trust badge (opposite signal, same DTO-exposure pattern).
-`phoneNumberHash` never appears here — like auth-code hashes, it's not
-something the client needs.
+Example (built in Phase 3, `createdAt` added in Phase 5/4 for the profile
+page's "member since"): `UserPublicDTO { username, honestyScore, isLowTrust,
+isPhoneVerified, createdAt }` — `isPhoneVerified` feeds a future "Verified"
+badge the same way `isLowTrust` feeds the low-trust badge (opposite signal,
+same DTO-exposure pattern). `phoneNumberHash` never appears here — like
+auth-code hashes, it's not something the client needs.
 
 Built in Phase 2 (schema): `MoviePublicDTO`, `TrailerOpinionPublicDTO`,
 `ReviewPublicDTO`, `VotePublicDTO`, `ConfigPublicDTO`. Notes specific to

--- a/server/serializers/tests/review.test.ts
+++ b/server/serializers/tests/review.test.ts
@@ -5,7 +5,8 @@ const user = {
 	email: 'critic7@example.com',
 	honestyScore: 45,
 	isPhoneVerified: true,
-	phoneNumberHash: 'salt:hash'
+	phoneNumberHash: 'salt:hash',
+	createdAt: new Date('2025-06-01T00:00:00.000Z')
 }
 
 const review = {
@@ -40,7 +41,8 @@ describe('review serializer allowlist', () => {
 			username: 'critic7',
 			honestyScore: 45,
 			isLowTrust: false,
-			isPhoneVerified: true
+			isPhoneVerified: true,
+			createdAt: user.createdAt
 		})
 	})
 

--- a/server/serializers/tests/trailer-opinion.test.ts
+++ b/server/serializers/tests/trailer-opinion.test.ts
@@ -5,7 +5,8 @@ const user = {
 	email: 'critic7@example.com',
 	honestyScore: 45,
 	isPhoneVerified: true,
-	phoneNumberHash: 'salt:hash'
+	phoneNumberHash: 'salt:hash',
+	createdAt: new Date('2025-06-01T00:00:00.000Z')
 }
 
 const opinion = {
@@ -31,7 +32,8 @@ describe('trailer opinion serializer allowlist', () => {
 			username: 'critic7',
 			honestyScore: 45,
 			isLowTrust: false,
-			isPhoneVerified: true
+			isPhoneVerified: true,
+			createdAt: user.createdAt
 		})
 	})
 

--- a/server/serializers/tests/users.test.js
+++ b/server/serializers/tests/users.test.js
@@ -5,14 +5,15 @@ const user = {
 	email: 'critic7@example.com',
 	honestyScore: 45,
 	isPhoneVerified: true,
-	phoneNumberHash: 'salt:hash'
+	phoneNumberHash: 'salt:hash',
+	createdAt: new Date('2026-01-01T00:00:00.000Z')
 }
 
 describe('user serializer allowlist', () => {
 	test('public DTO drops email and phoneNumberHash', () => {
 		const dto = toUserPublicDTO(user)
 
-		expect(Object.keys(dto).sort()).toEqual(['honestyScore', 'isLowTrust', 'isPhoneVerified', 'username'])
+		expect(Object.keys(dto).sort()).toEqual(['createdAt', 'honestyScore', 'isLowTrust', 'isPhoneVerified', 'username'])
 		expect(dto).not.toHaveProperty('email')
 		expect(dto).not.toHaveProperty('phoneNumberHash')
 	})

--- a/server/serializers/users.ts
+++ b/server/serializers/users.ts
@@ -6,6 +6,7 @@ export interface UserPublicDTO {
 	honestyScore: number
 	isLowTrust: boolean
 	isPhoneVerified: boolean
+	createdAt: Date
 }
 
 // Threshold defaults to Config's default rather than reading Config here —
@@ -19,6 +20,7 @@ export function toUserPublicDTO(
 		username: user.username,
 		honestyScore: user.honestyScore,
 		isLowTrust: user.honestyScore < lowTrustBadgeThreshold,
-		isPhoneVerified: user.isPhoneVerified
+		isPhoneVerified: user.isPhoneVerified,
+		createdAt: user.createdAt
 	}
 }


### PR DESCRIPTION
Make usernames clickable links to user profiles. Add profile card UI, types, routes, and server endpoints for viewing public user activity with pagination. Include member-since date and account settings placeholder for own profile. Add `createdAt` to UserPublicDTO allowlist for profile metadata.

## What

<!-- Summary of the change -->

## Data Minimization & Leak Prevention gate

Required for every PR touching an API response, logging, or error handling
(see `docs/plan/criticseven-modernization-plan.md`, Standing Requirement):

- [ ] Every API response goes through an explicit-allowlist DTO in `server/serializers/` — no raw model documents or upstream payloads sent to the client, no select-minus/denylist shaping
- [ ] No email, password/auth-code hashes, raw `HonestyLog` entries, or internal `_id` (where a public id suffices) in any response
- [ ] Error responses: generic message + error code only in production; full detail stays in server logs (central `errorHandler`, no per-route `res.status(500).send(error.message)`)
- [ ] No `console.log`/`console.error` of request bodies, user objects, auth codes, or raw upstream errors (axios errors embed the TMDB `api_key`)
- [ ] Request logging (morgan) does not log bodies; `/auth/*` URLs are logged without query strings

Auth routes only (Phase 3+):

- [ ] `POST /auth/verify-code` response never echoes the submitted or stored code
- [ ] `POST /auth/request-code` returns the identical response whether or not the email exists (no account enumeration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added user profile pages with membership details, trust badges, honesty scores, and review/opinion activity.
  - Added profile activity cards showing movie ratings, hype levels, and comments.
  - Added user profile, reviews, and opinions endpoints with pagination.
  - Made review and opinion author names link to their profiles.

- **Documentation**
  - Updated public profile documentation to include membership dates while excluding private contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->